### PR TITLE
Rename 'concept' -> 'classifier' in @lionweb/validation everywhere

### DIFF
--- a/packages/validation/src/diff/LionwebDiff.ts
+++ b/packages/validation/src/diff/LionwebDiff.ts
@@ -58,10 +58,10 @@ export class LwDiff {
     diffLwNode(obj1: LionWebJsonNode, obj2: LionWebJsonNode): void {
         // console.log("Comparing nodes")
         if (!isEqualMetaPointer(obj1.classifier, obj2.classifier)) {
-            this.error(`Object ${obj1.id} has concept ${JSON.stringify(obj1.classifier)} vs ${JSON.stringify(obj2.classifier)}`);
+            this.error(`Object ${obj1.id} has classifier ${JSON.stringify(obj1.classifier)} vs. ${JSON.stringify(obj2.classifier)}`);
         }
         if (obj1.parent !== obj2.parent) {
-            this.error(`Object ${obj1.id} has parent ${obj1.parent} vs ${obj2.parent}`);
+            this.error(`Object ${obj1.id} has parent ${obj1.parent} vs. ${obj2.parent}`);
         }
         for (const prop of obj1.properties) {
             const key = prop.property.key;

--- a/packages/validation/src/json/LionWebJsonChunkWrapper.ts
+++ b/packages/validation/src/json/LionWebJsonChunkWrapper.ts
@@ -50,7 +50,7 @@ export class LionWebJsonChunkWrapper {
             }
         }
         return result;
-        // return this.jsonChunk.nodes.filter(node => node.concept.key === conceptKey);
+        // return this.jsonChunk.nodes.filter(node => node.classifier.key === conceptKey);
     }
 
     allProperties(conceptNode: LionWebJsonNode): LionWebJsonProperty[] {

--- a/packages/validation/src/validators/LionWebSyntaxValidator.ts
+++ b/packages/validation/src/validators/LionWebSyntaxValidator.ts
@@ -97,7 +97,7 @@ export class LionWebSyntaxValidator {
     validateLwNode = (obj: unknown): void => {
         const expected: PropertyDefinition[] = [
             { property: "id", expectedType: "string", mayBeNull: NOT_NULL, validateValue: this.simpleFieldValidator.validateId },
-            { property: "concept", expectedType: "object", mayBeNull: NOT_NULL, validateValue: this.validateLwMetaPointer },
+            { property: "classifier", expectedType: "object", mayBeNull: NOT_NULL, validateValue: this.validateLwMetaPointer },
             { property: "properties", expectedType: "array", mayBeNull: NOT_NULL, validateValue: this.validateLwProperty },
             { property: "children", expectedType: "array", mayBeNull: NOT_NULL, validateValue: this.validateLwChild },
             { property: "references", expectedType: "array", mayBeNull: NOT_NULL, validateValue: this.validateLwReference },


### PR DESCRIPTION
Were a few missing instances, I think.