### PR TITLE
Ensure LionCore-builtins is mentioned in used languages when used

### DIFF
--- a/packages/artifacts/chunks/languages/builtins.json
+++ b/packages/artifacts/chunks/languages/builtins.json
@@ -4,6 +4,10 @@
     {
       "key": "LionCore-M3",
       "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
     }
   ],
   "nodes": [

--- a/packages/artifacts/chunks/languages/library.json
+++ b/packages/artifacts/chunks/languages/library.json
@@ -4,6 +4,10 @@
     {
       "key": "LionCore-M3",
       "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
     }
   ],
   "nodes": [

--- a/packages/artifacts/chunks/languages/lioncore.json
+++ b/packages/artifacts/chunks/languages/lioncore.json
@@ -4,6 +4,10 @@
     {
       "key": "LionCore-M3",
       "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
     }
   ],
   "nodes": [

--- a/packages/artifacts/chunks/languages/multi.json
+++ b/packages/artifacts/chunks/languages/multi.json
@@ -4,6 +4,10 @@
     {
       "key": "LionCore-M3",
       "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
     }
   ],
   "nodes": [

--- a/packages/artifacts/chunks/languages/shapes.json
+++ b/packages/artifacts/chunks/languages/shapes.json
@@ -4,6 +4,10 @@
     {
       "key": "LionCore-M3",
       "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
     }
   ],
   "nodes": [

--- a/packages/artifacts/chunks/languages/with-enum.json
+++ b/packages/artifacts/chunks/languages/with-enum.json
@@ -4,6 +4,10 @@
     {
       "key": "LionCore-M3",
       "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
     }
   ],
   "nodes": [

--- a/packages/core/src/serializer.ts
+++ b/packages/core/src/serializer.ts
@@ -105,7 +105,6 @@ export const serializeNodes = <NT extends Node>(nodes: NT[], extractionFacade: E
     return {
         serializationFormatVersion: currentSerializationFormatVersion,
         languages: languagesUsed
-            .filter((language) => !language.equals(lioncoreBuiltins))
             .map(({key, version}) => ({ key, version })),
         nodes: serializedNodes
     }

--- a/packages/test/src/m3/diagrams/diagrams.test.ts
+++ b/packages/test/src/m3/diagrams/diagrams.test.ts
@@ -54,7 +54,7 @@ const testLanguage = (() => {
 })()
 
 
-describe.only("rendering languages as PlantUML diagrams", () => {
+describe("rendering languages as PlantUML diagrams", () => {
 
     it("is improved", () => {
         rendersEqualToFileOrOverwrite(generatePlantUmlForLanguage, "test-diagram-expected.puml")
@@ -62,7 +62,7 @@ describe.only("rendering languages as PlantUML diagrams", () => {
 
 })
 
-describe.only("rendering languages as Mermaid diagrams", () => {
+describe("rendering languages as Mermaid diagrams", () => {
 
     it("is improved", () => {
         rendersEqualToFileOrOverwrite(generateMermaidForLanguage, "test-diagram-expected.md")


### PR DESCRIPTION
(`LionCore-builtins` is not an implicitly-used language.)