### PR TITLE
Support deserialization of custom primitive types

### DIFF
--- a/packages/core/src/deserializer.ts
+++ b/packages/core/src/deserializer.ts
@@ -4,7 +4,6 @@ import {InstantiationFacade} from "./facade.js"
 import {MemoisingSymbolTable} from "./symbol-table.js"
 import {Classifier, Containment, Enumeration, Language, PrimitiveType, Property, Reference} from "./m3/types.js"
 import {allFeaturesOf} from "./m3/functions.js"
-import { PrimitiveTypeSerializer } from "./m3/builtins.js"
 import {groupBy} from "./utils/map-helpers.js"
 
 
@@ -19,6 +18,9 @@ const byIdMap = <T extends { id: Id }>(ts: T[]): { [id: Id]: T } => {
     return map
 }
 
+export interface PrimitiveTypeDeserializer {
+    deserializeValue(value: string | undefined, property: Property): unknown | undefined
+}
 
 /**
  * @return a deserialization of a {@link SerializationChunk}
@@ -31,7 +33,7 @@ const byIdMap = <T extends { id: Id }>(ts: T[]): { [id: Id]: T } => {
 export const deserializeSerializationChunk = <NT extends Node>(
     serializationChunk: SerializationChunk,
     instantiationFacade: InstantiationFacade<NT>,
-    dataTypeSerializer: PrimitiveTypeSerializer,
+    primitiveTypeDeserializer: PrimitiveTypeDeserializer,
     languages: Language[],
     // TODO  facades <--> languages, so it's weird that it looks split up like this
     dependentNodes: Node[]
@@ -92,7 +94,7 @@ export const deserializeSerializationChunk = <NT extends Node>(
                     if (property.key in serializedPropertiesPerKey) {
                         const value = serializedPropertiesPerKey[property.key][0].value
                         if (property.type instanceof PrimitiveType) {
-                            propertySettings[property.key] = dataTypeSerializer.deserializeValue(value, property as Property);
+                            propertySettings[property.key] = primitiveTypeDeserializer.deserializeValue(value, property as Property);
                             return
                         }
                         if (property.type instanceof Enumeration) {

--- a/packages/core/src/deserializer.ts
+++ b/packages/core/src/deserializer.ts
@@ -4,7 +4,7 @@ import {InstantiationFacade} from "./facade.js"
 import {MemoisingSymbolTable} from "./symbol-table.js"
 import {Classifier, Containment, Enumeration, Language, PrimitiveType, Property, Reference} from "./m3/types.js"
 import {allFeaturesOf} from "./m3/functions.js"
-import {deserializeBuiltin} from "./m3/builtins.js"
+import { PrimitiveTypeSerializer } from "./m3/builtins.js"
 import {groupBy} from "./utils/map-helpers.js"
 
 
@@ -31,6 +31,7 @@ const byIdMap = <T extends { id: Id }>(ts: T[]): { [id: Id]: T } => {
 export const deserializeSerializationChunk = <NT extends Node>(
     serializationChunk: SerializationChunk,
     instantiationFacade: InstantiationFacade<NT>,
+    dataTypeSerializer: PrimitiveTypeSerializer,
     languages: Language[],
     // TODO  facades <--> languages, so it's weird that it looks split up like this
     dependentNodes: Node[]
@@ -91,7 +92,7 @@ export const deserializeSerializationChunk = <NT extends Node>(
                     if (property.key in serializedPropertiesPerKey) {
                         const value = serializedPropertiesPerKey[property.key][0].value
                         if (property.type instanceof PrimitiveType) {
-                            propertySettings[property.key] = deserializeBuiltin(value, property as Property)
+                            propertySettings[property.key] = dataTypeSerializer.deserializeValue(value, property as Property);
                             return
                         }
                         if (property.type instanceof Enumeration) {

--- a/packages/core/src/deserializer.ts
+++ b/packages/core/src/deserializer.ts
@@ -5,6 +5,7 @@ import {MemoisingSymbolTable} from "./symbol-table.js"
 import {Classifier, Containment, Enumeration, Language, PrimitiveType, Property, Reference} from "./m3/types.js"
 import {allFeaturesOf} from "./m3/functions.js"
 import {groupBy} from "./utils/map-helpers.js"
+import { DefaultPrimitiveTypeDeserializer } from "./m3/index.js"
 
 
 /**
@@ -33,11 +34,11 @@ export interface PrimitiveTypeDeserializer {
 export const deserializeSerializationChunk = <NT extends Node>(
     serializationChunk: SerializationChunk,
     instantiationFacade: InstantiationFacade<NT>,
-    primitiveTypeDeserializer: PrimitiveTypeDeserializer,
     languages: Language[],
     // TODO  facades <--> languages, so it's weird that it looks split up like this
-    dependentNodes: Node[]
+    dependentNodes: Node[],
     // TODO (#13)  see if you can turn this into [nodes: Node[], instantiationFacade: InstantiationFacade<Node>][] after all
+    primitiveTypeDeserializer: PrimitiveTypeDeserializer = new DefaultPrimitiveTypeDeserializer()
 ): NT[] => {
 
     if (serializationChunk.serializationFormatVersion !== currentSerializationFormatVersion) {

--- a/packages/core/src/m3/builtins.ts
+++ b/packages/core/src/m3/builtins.ts
@@ -2,6 +2,7 @@ import {LanguageFactory} from "./factory.js"
 import { Classifier, Concept, Datatype, lioncoreBuiltinsKey, Property } from "./types.js"
 import {StringsMapper} from "../utils/string-mapping.js"
 import {currentReleaseVersion} from "../version.js"
+import { PrimitiveTypeDeserializer } from "../deserializer.js"
 
 
 const lioncoreBuiltinsIdAndKeyGenerator: StringsMapper =
@@ -97,7 +98,7 @@ const serializeBuiltin = (value: BuiltinPrimitive): string => {
     throw new Error(`can't serialize value of built-in primitive type: ${value}`)
 }
 
-export class PrimitiveTypeSerializer {
+export class SimplePrimitiveTypeDeserializer implements PrimitiveTypeDeserializer {
 
     private deserializerByType = new Map<Datatype, SpecificPrimitiveTypeDeserializer>()
 
@@ -131,7 +132,6 @@ export class PrimitiveTypeSerializer {
         }
     }
 }
-
 
 export type {
     BuiltinPrimitive

--- a/packages/core/src/m3/builtins.ts
+++ b/packages/core/src/m3/builtins.ts
@@ -2,7 +2,6 @@ import {LanguageFactory} from "./factory.js"
 import { Classifier, Concept, Datatype, lioncoreBuiltinsKey, Property } from "./types.js"
 import {StringsMapper} from "../utils/string-mapping.js"
 import {currentReleaseVersion} from "../version.js"
-import { LionCore_builtins_Json, LIONWEB_INTEGER_TYPE } from "@lionweb/validation"
 
 
 const lioncoreBuiltinsIdAndKeyGenerator: StringsMapper =

--- a/packages/core/src/m3/builtins.ts
+++ b/packages/core/src/m3/builtins.ts
@@ -61,7 +61,7 @@ lioncoreBuiltins.havingEntities(
 
 
 type BuiltinPrimitive = string | boolean | number | Record<string, unknown> | Array<unknown>
-type PrimitiveTypeValue = BuiltinPrimitive | any
+type PrimitiveTypeValue = BuiltinPrimitive | unknown
 type SpecificPrimitiveTypeDeserializer = (value: string)=>PrimitiveTypeValue
 
 const builtinPrimitives = {
@@ -120,7 +120,10 @@ export class PrimitiveTypeSerializer {
             throw new Error(`can't deserialize undefined as the value of a required property`)
         }
         const { type } = property
-        const specificDeserializer = this.deserializerByType.get(type!!)
+        if (type == null) {
+            throw new Error(`cant't deserialize a property with unspecified type`)
+        }
+        const specificDeserializer = this.deserializerByType.get(type)
         if (specificDeserializer != null) {
             return specificDeserializer(value)
         } else {

--- a/packages/core/src/m3/builtins.ts
+++ b/packages/core/src/m3/builtins.ts
@@ -98,7 +98,7 @@ const serializeBuiltin = (value: BuiltinPrimitive): string => {
     throw new Error(`can't serialize value of built-in primitive type: ${value}`)
 }
 
-export class SimplePrimitiveTypeDeserializer implements PrimitiveTypeDeserializer {
+export class DefaultPrimitiveTypeDeserializer implements PrimitiveTypeDeserializer {
 
     private deserializerByType = new Map<Datatype, SpecificPrimitiveTypeDeserializer>()
 

--- a/packages/core/src/m3/deserializer.ts
+++ b/packages/core/src/m3/deserializer.ts
@@ -4,8 +4,7 @@ import {lioncoreExtractionFacade, lioncoreInstantiationFacade} from "./facade.js
 import {nodesExtractorUsing} from "../facade.js"
 import {deserializeSerializationChunk} from "../deserializer.js"
 import {lioncore} from "./lioncore.js"
-import {lioncoreBuiltins} from "./builtins.js"
-
+import { lioncoreBuiltins, PrimitiveTypeSerializer } from "./builtins.js"
 
 /**
  * Deserializes languages that have been serialized into the LionWeb serialization JSON format
@@ -15,6 +14,7 @@ export const deserializeLanguages = (serializationChunk: SerializationChunk, ...
     deserializeSerializationChunk(
         serializationChunk,
         lioncoreInstantiationFacade,
+        new PrimitiveTypeSerializer(),
         [lioncore],
         [lioncoreBuiltins, ...dependentLanguages].flatMap(nodesExtractorUsing(lioncoreExtractionFacade))
     )

--- a/packages/core/src/m3/deserializer.ts
+++ b/packages/core/src/m3/deserializer.ts
@@ -4,7 +4,7 @@ import {lioncoreExtractionFacade, lioncoreInstantiationFacade} from "./facade.js
 import {nodesExtractorUsing} from "../facade.js"
 import {deserializeSerializationChunk} from "../deserializer.js"
 import {lioncore} from "./lioncore.js"
-import { lioncoreBuiltins, PrimitiveTypeSerializer } from "./builtins.js"
+import { lioncoreBuiltins, SimplePrimitiveTypeDeserializer } from "./builtins.js"
 
 /**
  * Deserializes languages that have been serialized into the LionWeb serialization JSON format
@@ -14,7 +14,7 @@ export const deserializeLanguages = (serializationChunk: SerializationChunk, ...
     deserializeSerializationChunk(
         serializationChunk,
         lioncoreInstantiationFacade,
-        new PrimitiveTypeSerializer(),
+        new SimplePrimitiveTypeDeserializer(),
         [lioncore],
         [lioncoreBuiltins, ...dependentLanguages].flatMap(nodesExtractorUsing(lioncoreExtractionFacade))
     )

--- a/packages/core/src/m3/deserializer.ts
+++ b/packages/core/src/m3/deserializer.ts
@@ -4,7 +4,7 @@ import {lioncoreExtractionFacade, lioncoreInstantiationFacade} from "./facade.js
 import {nodesExtractorUsing} from "../facade.js"
 import {deserializeSerializationChunk} from "../deserializer.js"
 import {lioncore} from "./lioncore.js"
-import { lioncoreBuiltins, SimplePrimitiveTypeDeserializer } from "./builtins.js"
+import { lioncoreBuiltins, DefaultPrimitiveTypeDeserializer } from "./builtins.js"
 
 /**
  * Deserializes languages that have been serialized into the LionWeb serialization JSON format
@@ -14,7 +14,6 @@ export const deserializeLanguages = (serializationChunk: SerializationChunk, ...
     deserializeSerializationChunk(
         serializationChunk,
         lioncoreInstantiationFacade,
-        new SimplePrimitiveTypeDeserializer(),
         [lioncore],
         [lioncoreBuiltins, ...dependentLanguages].flatMap(nodesExtractorUsing(lioncoreExtractionFacade))
     )

--- a/packages/core/src/m3/deserializer.ts
+++ b/packages/core/src/m3/deserializer.ts
@@ -4,7 +4,7 @@ import {lioncoreExtractionFacade, lioncoreInstantiationFacade} from "./facade.js
 import {nodesExtractorUsing} from "../facade.js"
 import {deserializeSerializationChunk} from "../deserializer.js"
 import {lioncore} from "./lioncore.js"
-import { lioncoreBuiltins, DefaultPrimitiveTypeDeserializer } from "./builtins.js"
+import { lioncoreBuiltins } from "./builtins.js"
 
 /**
  * Deserializes languages that have been serialized into the LionWeb serialization JSON format

--- a/packages/test/src/deserializer.test.ts
+++ b/packages/test/src/deserializer.test.ts
@@ -4,7 +4,7 @@ const {deepEqual} = assert
 import {
     currentSerializationFormatVersion,
     deserializeSerializationChunk, Feature, InstantiationFacade,
-    SimplePrimitiveTypeDeserializer,
+    DefaultPrimitiveTypeDeserializer,
     SerializationChunk,
 } from "@lionweb/core"
 import { BaseNode, libraryInstantiationFacade } from "./instances/library.js"
@@ -57,7 +57,7 @@ describe("deserialization", () => {
             ]
         }
         const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade,
-                            new SimplePrimitiveTypeDeserializer(),
+                            new DefaultPrimitiveTypeDeserializer(),
             [libraryLanguage], [])
         deepEqual(
             deserialization,
@@ -106,7 +106,7 @@ describe("deserialization", () => {
             ]
         }
         expect(() => deserializeSerializationChunk(serializationChunk, libraryWithDatesInstantiationFacade,
-            new SimplePrimitiveTypeDeserializer(),
+            new DefaultPrimitiveTypeDeserializer(),
             [libraryWithDatesLanguage], []))
             .to.throw();
     })
@@ -145,15 +145,15 @@ describe("deserialization", () => {
                 }
             ]
         }
-        const primitiveTypeDeserializer = new SimplePrimitiveTypeDeserializer();
+        const primitiveTypeDeserializer = new DefaultPrimitiveTypeDeserializer();
         primitiveTypeDeserializer.registerDeserializer(dateDatatype, (value)=> {
             const parts = value.split("-");
             return new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]))
         })
 
         const deserialization = deserializeSerializationChunk(serializationChunk, libraryWithDatesInstantiationFacade,
-            primitiveTypeDeserializer,
-            [libraryWithDatesLanguage], [])
+            [libraryWithDatesLanguage], [],
+            primitiveTypeDeserializer)
 
         const node = deserialization[0] as NodeWithProperties;
         expect(node.properties["creationDate"]).to.eql(new Date(2024, 4, 28))

--- a/packages/test/src/deserializer.test.ts
+++ b/packages/test/src/deserializer.test.ts
@@ -11,6 +11,8 @@ import { BaseNode, libraryInstantiationFacade } from "./instances/library.js"
 import {libraryLanguage} from "./languages/library.js"
 import { dateDatatype, libraryWithDatesLanguage } from "./languages/libraryWithDates.js"
 
+type NodeWithProperties = BaseNode & {properties:Record<string, unknown>}
+
 export const libraryWithDatesInstantiationFacade: InstantiationFacade<BaseNode> = {
     nodeFor: (_parent, classifier, id, _propertySettings) => ({
         id,
@@ -18,10 +20,10 @@ export const libraryWithDatesInstantiationFacade: InstantiationFacade<BaseNode> 
         annotations: [],
         properties: {}
     }),
-    setFeatureValue: (node: any, feature: Feature, value: unknown) => {
-        node.properties[feature.name] = value
+    setFeatureValue: (node: BaseNode, feature: Feature, value: unknown) => {
+        (node as NodeWithProperties).properties[feature.name] = value
     },
-    encodingOf: (literal) => {
+    encodingOf: () => {
         throw new Error()
     }
 }
@@ -153,7 +155,7 @@ describe("deserialization", () => {
             primitiveTypeSerializer,
             [libraryWithDatesLanguage], [])
 
-        const node = deserialization[0] as any;
+        const node = deserialization[0] as NodeWithProperties;
         expect(node.properties["creationDate"]).to.eql(new Date(2024, 4, 28))
     })
 

--- a/packages/test/src/deserializer.test.ts
+++ b/packages/test/src/deserializer.test.ts
@@ -5,11 +5,11 @@ import {
     currentSerializationFormatVersion,
     deserializeSerializationChunk, Feature, InstantiationFacade,
     PrimitiveTypeSerializer,
-    SerializationChunk, updateSettingsNameBased
+    SerializationChunk,
 } from "@lionweb/core"
 import { BaseNode, libraryInstantiationFacade } from "./instances/library.js"
 import {libraryLanguage} from "./languages/library.js"
-import { dateDatatype, libraryWithDates, libraryWithDatesLanguage } from "./languages/libraryWithDates.js"
+import { dateDatatype, libraryWithDatesLanguage } from "./languages/libraryWithDates.js"
 
 export const libraryWithDatesInstantiationFacade: InstantiationFacade<BaseNode> = {
     nodeFor: (_parent, classifier, id, _propertySettings) => ({

--- a/packages/test/src/deserializer.test.ts
+++ b/packages/test/src/deserializer.test.ts
@@ -4,7 +4,7 @@ const {deepEqual} = assert
 import {
     currentSerializationFormatVersion,
     deserializeSerializationChunk, Feature, InstantiationFacade,
-    PrimitiveTypeSerializer,
+    SimplePrimitiveTypeDeserializer,
     SerializationChunk,
 } from "@lionweb/core"
 import { BaseNode, libraryInstantiationFacade } from "./instances/library.js"
@@ -57,7 +57,7 @@ describe("deserialization", () => {
             ]
         }
         const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade,
-                            new PrimitiveTypeSerializer(),
+                            new SimplePrimitiveTypeDeserializer(),
             [libraryLanguage], [])
         deepEqual(
             deserialization,
@@ -106,7 +106,7 @@ describe("deserialization", () => {
             ]
         }
         expect(() => deserializeSerializationChunk(serializationChunk, libraryWithDatesInstantiationFacade,
-            new PrimitiveTypeSerializer(),
+            new SimplePrimitiveTypeDeserializer(),
             [libraryWithDatesLanguage], []))
             .to.throw();
     })
@@ -145,14 +145,14 @@ describe("deserialization", () => {
                 }
             ]
         }
-        const primitiveTypeSerializer = new PrimitiveTypeSerializer();
-        primitiveTypeSerializer.registerDeserializer(dateDatatype, (value)=> {
+        const primitiveTypeDeserializer = new SimplePrimitiveTypeDeserializer();
+        primitiveTypeDeserializer.registerDeserializer(dateDatatype, (value)=> {
             const parts = value.split("-");
             return new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]))
         })
 
         const deserialization = deserializeSerializationChunk(serializationChunk, libraryWithDatesInstantiationFacade,
-            primitiveTypeSerializer,
+            primitiveTypeDeserializer,
             [libraryWithDatesLanguage], [])
 
         const node = deserialization[0] as NodeWithProperties;

--- a/packages/test/src/deserializer.test.ts
+++ b/packages/test/src/deserializer.test.ts
@@ -1,7 +1,12 @@
 import {assert} from "chai"
 const {deepEqual} = assert
 
-import {currentSerializationFormatVersion, deserializeSerializationChunk, SerializationChunk} from "@lionweb/core"
+import {
+    currentSerializationFormatVersion,
+    deserializeSerializationChunk,
+    PrimitiveTypeSerializer,
+    SerializationChunk
+} from "@lionweb/core"
 import {libraryInstantiationFacade} from "./instances/library.js"
 import {libraryLanguage} from "./languages/library.js"
 
@@ -33,7 +38,9 @@ describe("deserialization", () => {
                 }
             ]
         }
-        const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade, [libraryLanguage], [])
+        const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade,
+                            new PrimitiveTypeSerializer(),
+            [libraryLanguage], [])
         deepEqual(
             deserialization,
             [

--- a/packages/test/src/deserializer.test.ts
+++ b/packages/test/src/deserializer.test.ts
@@ -57,7 +57,6 @@ describe("deserialization", () => {
             ]
         }
         const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade,
-                            new DefaultPrimitiveTypeDeserializer(),
             [libraryLanguage], [])
         deepEqual(
             deserialization,
@@ -106,7 +105,6 @@ describe("deserialization", () => {
             ]
         }
         expect(() => deserializeSerializationChunk(serializationChunk, libraryWithDatesInstantiationFacade,
-            new DefaultPrimitiveTypeDeserializer(),
             [libraryWithDatesLanguage], []))
             .to.throw();
     })

--- a/packages/test/src/deserializer.test.ts
+++ b/packages/test/src/deserializer.test.ts
@@ -1,14 +1,30 @@
-import {assert} from "chai"
+import { assert, expect } from "chai"
 const {deepEqual} = assert
 
 import {
     currentSerializationFormatVersion,
-    deserializeSerializationChunk,
+    deserializeSerializationChunk, Feature, InstantiationFacade,
     PrimitiveTypeSerializer,
-    SerializationChunk
+    SerializationChunk, updateSettingsNameBased
 } from "@lionweb/core"
-import {libraryInstantiationFacade} from "./instances/library.js"
+import { BaseNode, libraryInstantiationFacade } from "./instances/library.js"
 import {libraryLanguage} from "./languages/library.js"
+import { dateDatatype, libraryWithDates, libraryWithDatesLanguage } from "./languages/libraryWithDates.js"
+
+export const libraryWithDatesInstantiationFacade: InstantiationFacade<BaseNode> = {
+    nodeFor: (_parent, classifier, id, _propertySettings) => ({
+        id,
+        classifier: classifier.key,
+        annotations: [],
+        properties: {}
+    }),
+    setFeatureValue: (node: any, feature: Feature, value: unknown) => {
+        node.properties[feature.name] = value
+    },
+    encodingOf: (literal) => {
+        throw new Error()
+    }
+}
 
 
 describe("deserialization", () => {
@@ -51,6 +67,94 @@ describe("deserialization", () => {
                 }   // is instantiated despite its serialization specifying a non-null parent ID that's not resolvable within the serialization chunk
             ]
         )
+    })
+
+    it("deserializes node with custom primitive type, without registering custom deserializer", () => {
+        const serializationChunk: SerializationChunk = {
+            serializationFormatVersion: currentSerializationFormatVersion,
+            "languages": [
+                {
+                    "key": "library-with-dates",
+                    "version": "1"
+                }
+            ],
+            nodes: [
+                {
+                    id: "1",
+                    classifier: {
+                        language: "library-with-dates",
+                        version: "1",
+                        key: "Library"
+                    },
+                    properties: [
+                        {
+                            property: {
+                                language: "library-with-dates",
+                                version: "1",
+                                key: "Library-creation-date"
+                            },
+                            value: "2024-05-28"
+                        }
+                    ],
+                    containments: [],
+                    references: [],
+                    annotations: [],
+                    parent: null
+                }
+            ]
+        }
+        expect(() => deserializeSerializationChunk(serializationChunk, libraryWithDatesInstantiationFacade,
+            new PrimitiveTypeSerializer(),
+            [libraryWithDatesLanguage], []))
+            .to.throw();
+    })
+
+    it("deserializes node with custom primitive type, works when registering custom deserializer", () => {
+        const serializationChunk: SerializationChunk = {
+            serializationFormatVersion: currentSerializationFormatVersion,
+            "languages": [
+                {
+                    "key": "libraryWithDates",
+                    "version": "1"
+                }
+            ],
+            nodes: [
+                {
+                    id: "1",
+                    classifier: {
+                        language: "libraryWithDates",
+                        version: "1",
+                        key: "LibraryWithDates"
+                    },
+                    properties: [
+                        {
+                            property: {
+                                language: "libraryWithDates",
+                                version: "1",
+                                key: "library_Library_creationDate"
+                            },
+                            value: "2024-05-28"
+                        }
+                    ],
+                    containments: [],
+                    references: [],
+                    annotations: [],
+                    parent: null
+                }
+            ]
+        }
+        const primitiveTypeSerializer = new PrimitiveTypeSerializer();
+        primitiveTypeSerializer.registerDeserializer(dateDatatype, (value)=> {
+            const parts = value.split("-");
+            return new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]))
+        })
+
+        const deserialization = deserializeSerializationChunk(serializationChunk, libraryWithDatesInstantiationFacade,
+            primitiveTypeSerializer,
+            [libraryWithDatesLanguage], [])
+
+        const node = deserialization[0] as any;
+        expect(node.properties["creationDate"]).to.eql(new Date(2024, 4, 28))
     })
 
 })

--- a/packages/test/src/languages/libraryWithDates.ts
+++ b/packages/test/src/languages/libraryWithDates.ts
@@ -1,0 +1,58 @@
+import {builtinPrimitives, chain, concatenator, LanguageFactory, lastOf} from "@lionweb/core"
+import {hasher} from "@lionweb/utilities"
+
+
+const factory = new LanguageFactory(
+    "libraryWithDates",
+    "1",
+    chain(concatenator("-"), hasher()),
+    lastOf
+)
+export const libraryWithDatesLanguage = factory.language
+
+const {integerDatatype, stringDatatype} = builtinPrimitives
+
+export const libraryWithDates = factory.concept("LibraryWithDates", false)
+const book = factory.concept("Book", false)
+const writer = factory.concept("Writer", false)
+const guideBookWriter = factory.concept("GuideBookWriter", false, writer)
+const specialistBookWriter = factory.concept("SpecialistBookWriter", false, writer)
+const bookType = factory.enumeration("BookType")
+bookType.havingLiterals(
+        factory.enumerationLiteral(bookType, "Normal"),
+        factory.enumerationLiteral(bookType, "Special")
+    )
+export const dateDatatype = factory.primitiveType("Date")
+
+const library_name = factory.property(libraryWithDates, "name").ofType(stringDatatype).havingKey("library_Library_name")
+const library_creationDate = factory.property(libraryWithDates, "creationDate").ofType(dateDatatype).havingKey("library_Library_creationDate")
+const library_books = factory.containment(libraryWithDates, "books").ofType(book).isMultiple()
+libraryWithDates.havingFeatures(library_name, library_books, library_creationDate)
+
+const book_title = factory.property(book, "title").ofType(stringDatatype)
+const book_pages = factory.property(book, "pages").ofType(integerDatatype)
+const book_author = factory.reference(book, "author").ofType(writer)
+const book_type = factory.property(book, "type").ofType(bookType).isOptional()
+book.havingFeatures(book_title, book_pages, book_author, book_type)
+
+const writer_name = factory.property(writer, "name").ofType(stringDatatype).havingKey("library_Writer_name")
+writer.havingFeatures(writer_name)
+// Note: writers are _not_ contained in the library (node) itself, so are separate nodes.
+
+const guideBookWriter_countries = factory.property(guideBookWriter, "countries").ofType(stringDatatype)
+guideBookWriter.havingFeatures(guideBookWriter_countries)
+
+const specialistBookWriter_subject = factory.property(specialistBookWriter, "subject").ofType(stringDatatype)
+specialistBookWriter.havingFeatures(specialistBookWriter_subject)
+
+
+libraryWithDatesLanguage.havingEntities(
+    book,
+    bookType,
+    libraryWithDates,
+    dateDatatype,
+    writer,
+    guideBookWriter,
+    specialistBookWriter
+)
+

--- a/packages/test/src/library.test.ts
+++ b/packages/test/src/library.test.ts
@@ -6,7 +6,7 @@ import {
     DynamicNode,
     dynamicInstantiationFacade,
     nameBasedClassifierDeducerFor,
-    serializeNodes
+    serializeNodes, PrimitiveTypeSerializer
 } from "@lionweb/core"
 import {libraryModel, libraryExtractionFacade, libraryInstantiationFacade} from "./instances/library.js"
 import {libraryLanguage} from "./languages/library.js"
@@ -17,13 +17,17 @@ describe("Library test model", () => {
     it("[de-]serialize example library", () => {
         const serializationChunk = serializeNodes(libraryModel, libraryExtractionFacade)
         // FIXME  ensure that serialization does not produce key-value pairs with value === undefined
-        const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade, [libraryLanguage], [])
+        const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade,
+                            new PrimitiveTypeSerializer(),
+            [libraryLanguage], [])
         deepEqual(deserialization, libraryModel)
     })
 
     it(`"dynamify" example library through serialization and deserialization using the DynamicNode facades`, () => {
         const serializationChunk = serializeNodes(libraryModel, libraryExtractionFacade)
-        const dynamification = deserializeSerializationChunk(serializationChunk, dynamicInstantiationFacade, [libraryLanguage], [])
+        const dynamification = deserializeSerializationChunk(serializationChunk, dynamicInstantiationFacade,
+            new PrimitiveTypeSerializer(),
+            [libraryLanguage], [])
         deepEqual(dynamification.length, 2)
         const lookup = nameBasedClassifierDeducerFor(libraryLanguage)
         deepEqual(dynamification[0].classifier, lookup("Library"))

--- a/packages/test/src/library.test.ts
+++ b/packages/test/src/library.test.ts
@@ -6,7 +6,7 @@ import {
     DynamicNode,
     dynamicInstantiationFacade,
     nameBasedClassifierDeducerFor,
-    serializeNodes, PrimitiveTypeSerializer
+    serializeNodes, SimplePrimitiveTypeDeserializer
 } from "@lionweb/core"
 import {libraryModel, libraryExtractionFacade, libraryInstantiationFacade} from "./instances/library.js"
 import {libraryLanguage} from "./languages/library.js"
@@ -18,7 +18,7 @@ describe("Library test model", () => {
         const serializationChunk = serializeNodes(libraryModel, libraryExtractionFacade)
         // FIXME  ensure that serialization does not produce key-value pairs with value === undefined
         const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade,
-                            new PrimitiveTypeSerializer(),
+                            new SimplePrimitiveTypeDeserializer(),
             [libraryLanguage], [])
         deepEqual(deserialization, libraryModel)
     })
@@ -26,7 +26,7 @@ describe("Library test model", () => {
     it(`"dynamify" example library through serialization and deserialization using the DynamicNode facades`, () => {
         const serializationChunk = serializeNodes(libraryModel, libraryExtractionFacade)
         const dynamification = deserializeSerializationChunk(serializationChunk, dynamicInstantiationFacade,
-            new PrimitiveTypeSerializer(),
+            new SimplePrimitiveTypeDeserializer(),
             [libraryLanguage], [])
         deepEqual(dynamification.length, 2)
         const lookup = nameBasedClassifierDeducerFor(libraryLanguage)

--- a/packages/test/src/library.test.ts
+++ b/packages/test/src/library.test.ts
@@ -6,7 +6,7 @@ import {
     DynamicNode,
     dynamicInstantiationFacade,
     nameBasedClassifierDeducerFor,
-    serializeNodes, SimplePrimitiveTypeDeserializer
+    serializeNodes, DefaultPrimitiveTypeDeserializer
 } from "@lionweb/core"
 import {libraryModel, libraryExtractionFacade, libraryInstantiationFacade} from "./instances/library.js"
 import {libraryLanguage} from "./languages/library.js"
@@ -18,7 +18,7 @@ describe("Library test model", () => {
         const serializationChunk = serializeNodes(libraryModel, libraryExtractionFacade)
         // FIXME  ensure that serialization does not produce key-value pairs with value === undefined
         const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade,
-                            new SimplePrimitiveTypeDeserializer(),
+                            new DefaultPrimitiveTypeDeserializer(),
             [libraryLanguage], [])
         deepEqual(deserialization, libraryModel)
     })
@@ -26,7 +26,6 @@ describe("Library test model", () => {
     it(`"dynamify" example library through serialization and deserialization using the DynamicNode facades`, () => {
         const serializationChunk = serializeNodes(libraryModel, libraryExtractionFacade)
         const dynamification = deserializeSerializationChunk(serializationChunk, dynamicInstantiationFacade,
-            new SimplePrimitiveTypeDeserializer(),
             [libraryLanguage], [])
         deepEqual(dynamification.length, 2)
         const lookup = nameBasedClassifierDeducerFor(libraryLanguage)

--- a/packages/test/src/library.test.ts
+++ b/packages/test/src/library.test.ts
@@ -6,7 +6,7 @@ import {
     DynamicNode,
     dynamicInstantiationFacade,
     nameBasedClassifierDeducerFor,
-    serializeNodes, DefaultPrimitiveTypeDeserializer
+    serializeNodes
 } from "@lionweb/core"
 import {libraryModel, libraryExtractionFacade, libraryInstantiationFacade} from "./instances/library.js"
 import {libraryLanguage} from "./languages/library.js"
@@ -18,7 +18,6 @@ describe("Library test model", () => {
         const serializationChunk = serializeNodes(libraryModel, libraryExtractionFacade)
         // FIXME  ensure that serialization does not produce key-value pairs with value === undefined
         const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade,
-                            new DefaultPrimitiveTypeDeserializer(),
             [libraryLanguage], [])
         deepEqual(deserialization, libraryModel)
     })

--- a/packages/test/src/multi.test.ts
+++ b/packages/test/src/multi.test.ts
@@ -1,7 +1,7 @@
 import {assert} from "chai"
 const {deepEqual} = assert
 
-import {deserializeSerializationChunk, serializeNodes} from "@lionweb/core"
+import { deserializeSerializationChunk, PrimitiveTypeSerializer, serializeNodes } from "@lionweb/core"
 import {libraryLanguage} from "./languages/library.js"
 import {multiLanguage} from "./languages/multi.js"
 import {libraryInstantiationFacade} from "./instances/library.js"
@@ -12,7 +12,8 @@ describe("multi-language test model", () => {
 
     it("[de-]serialize multi-language model", () => {
         const serializationChunk = serializeNodes(multiModel, multiExtractionFacade)
-        const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade, [libraryLanguage, multiLanguage], [])
+        const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade,
+            new PrimitiveTypeSerializer(),[libraryLanguage, multiLanguage], [])
         deepEqual(deserialization, multiModel)
     })
 

--- a/packages/test/src/multi.test.ts
+++ b/packages/test/src/multi.test.ts
@@ -1,7 +1,7 @@
 import {assert} from "chai"
 const {deepEqual} = assert
 
-import { deserializeSerializationChunk, PrimitiveTypeSerializer, serializeNodes } from "@lionweb/core"
+import { deserializeSerializationChunk, SimplePrimitiveTypeDeserializer, serializeNodes } from "@lionweb/core"
 import {libraryLanguage} from "./languages/library.js"
 import {multiLanguage} from "./languages/multi.js"
 import {libraryInstantiationFacade} from "./instances/library.js"
@@ -13,7 +13,7 @@ describe("multi-language test model", () => {
     it("[de-]serialize multi-language model", () => {
         const serializationChunk = serializeNodes(multiModel, multiExtractionFacade)
         const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade,
-            new PrimitiveTypeSerializer(),[libraryLanguage, multiLanguage], [])
+            new SimplePrimitiveTypeDeserializer(),[libraryLanguage, multiLanguage], [])
         deepEqual(deserialization, multiModel)
     })
 

--- a/packages/test/src/multi.test.ts
+++ b/packages/test/src/multi.test.ts
@@ -1,7 +1,7 @@
 import {assert} from "chai"
 const {deepEqual} = assert
 
-import { deserializeSerializationChunk, DefaultPrimitiveTypeDeserializer, serializeNodes } from "@lionweb/core"
+import { deserializeSerializationChunk, serializeNodes } from "@lionweb/core"
 import {libraryLanguage} from "./languages/library.js"
 import {multiLanguage} from "./languages/multi.js"
 import {libraryInstantiationFacade} from "./instances/library.js"

--- a/packages/test/src/multi.test.ts
+++ b/packages/test/src/multi.test.ts
@@ -1,7 +1,7 @@
 import {assert} from "chai"
 const {deepEqual} = assert
 
-import { deserializeSerializationChunk, SimplePrimitiveTypeDeserializer, serializeNodes } from "@lionweb/core"
+import { deserializeSerializationChunk, DefaultPrimitiveTypeDeserializer, serializeNodes } from "@lionweb/core"
 import {libraryLanguage} from "./languages/library.js"
 import {multiLanguage} from "./languages/multi.js"
 import {libraryInstantiationFacade} from "./instances/library.js"
@@ -13,7 +13,7 @@ describe("multi-language test model", () => {
     it("[de-]serialize multi-language model", () => {
         const serializationChunk = serializeNodes(multiModel, multiExtractionFacade)
         const deserialization = deserializeSerializationChunk(serializationChunk, libraryInstantiationFacade,
-            new SimplePrimitiveTypeDeserializer(),[libraryLanguage, multiLanguage], [])
+            [libraryLanguage, multiLanguage], [])
         deepEqual(deserialization, multiModel)
     })
 


### PR DESCRIPTION
Based on the discussion we had during the meeting on the 25th of May, my understanding is that the different implementation of the libraries can provide custom deserializers for primitive types, as this is not something defined by the specification (neither required or forbidden).

So I thought I could put together an initial implementation to start the conversation.

In this PR we:
- Permit to define custom primitive type deserializers
- We convert the builtin primitive types to use those primitive type deserializers. That also means that someone could, potentially, override the default way in which primitive types are serialized
- Add a simple test to check the mechanism

If the general approach works I could also add support for primitive type serializer.

I am no TS or functional code expert, so I thought it made sense to open a PR early to check if I am going in a direction that makes sense for the library. Feedback is very well appreciated :)

Fix #156 