### PR TITLE
Skip empty (unset) feature values during serialization

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
     1. `serializeEmptyValues`: a boolean flag that determines whether empty (unset) feature values are explicitly serialized or skipped during serialization.
         This potentially reduces the size of the serialization substantially, helping with performance.
-        The default value is `true`, meaning that empty values – currently of containment and reference features – are explicitly serialized.
+        The default value is `true`, meaning that empty values are explicitly serialized — either as `null` for properties, or `[]` for links.
     2. `primitiveTypeSerializer`: an implementation of the `PrimitiveTypeSerializer` interface type.
         The default value is an instance of `DefaultPrimitiveTypeSerializer`.
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,19 @@
 ## 0.6.12 - not yet released
 
 * `LanguageFactory` instances take care of containment: e.g., creating an entity automatically adds that to the language, and likewise for features (to classifiers) and literals (to enumerations). 
+* Add an object type `SerializationOptions` to configure the `serializeNodes` function.
+    All options (which are all optional) are:
+
+    1. `skipEmptyValues`: a boolean flag that determines whether empty (unset) feature values are skipped during serialization.
+        This potentially reduces the size of the serialization substantially, helping with performance.
+        The default value is `false`, meaning that empty values – currently of containment and reference features – are explicitly serialized.
+    2. `primitiveTypeSerializer`: an implementation of the `PrimitiveTypeSerializer` interface type.
+        The default value is an instance of `DefaultPrimitiveTypeSerializer`.
+
+    A primitive type serializer can be passed to `serializeNodes` in two ways:
+
+    1. Via the `primitiveTypeSerializer` field of the `SerializationOptions` object that's passed as the 3rd argument.
+    2. Directly as the 3rd argument. (*Warning!* This way may become deprecated in the future.)
 
 
 ## 0.6.11

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,9 +6,9 @@
 * Add an object type `SerializationOptions` to configure the `serializeNodes` function.
     All options (which are all optional) are:
 
-    1. `skipEmptyValues`: a boolean flag that determines whether empty (unset) feature values are skipped during serialization.
+    1. `serializeEmptyValues`: a boolean flag that determines whether empty (unset) feature values are explicitly serialized or skipped during serialization.
         This potentially reduces the size of the serialization substantially, helping with performance.
-        The default value is `false`, meaning that empty values – currently of containment and reference features – are explicitly serialized.
+        The default value is `true`, meaning that empty values – currently of containment and reference features – are explicitly serialized.
     2. `primitiveTypeSerializer`: an implementation of the `PrimitiveTypeSerializer` interface type.
         The default value is an instance of `DefaultPrimitiveTypeSerializer`.
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.6.12 - not yet released
 
+* `LanguageFactory` instances take care of containment: e.g., creating an entity automatically adds that to the language, and likewise for features (to classifiers) and literals (to enumerations). 
+
+
 ## 0.6.11
 
 * Separate CHANGELOG from README.

--- a/packages/core/src/m3/builtins.ts
+++ b/packages/core/src/m3/builtins.ts
@@ -49,18 +49,6 @@ const inamed = factory.interface("INamed")
 const inamed_name = factory.property(inamed, "name")
     .ofType(stringDatatype)
 
-inamed.havingFeatures(inamed_name)
-
-
-lioncoreBuiltins.havingEntities(
-    stringDatatype,
-    booleanDatatype,
-    integerDatatype,
-    jsonDatatype,
-    node,
-    inamed
-)
-
 
 type BuiltinPrimitive = string | boolean | number | Record<string, unknown> | Array<unknown>
 type PrimitiveTypeValue = BuiltinPrimitive | unknown

--- a/packages/core/src/m3/factory.ts
+++ b/packages/core/src/m3/factory.ts
@@ -17,7 +17,13 @@ import {StringsMapper} from "../utils/string-mapping.js"
 
 /**
  * A factory that produces a {@link Language} instance,
- * as well as elements contained by that instance.
+ * as well as {@link LanguageEntity entities} contained by that instance
+ * and {@link Feature features} of {@link Classifier classifiers}
+ * and {@link EnumerationLiteral enumeration literals} of {@link Enumeration enumerations}.
+ *
+ * The factory methods take care of proper containment.
+ * *Note:* also calling `havingEntities`, `havingFeatures`, and `havingLiterals` doesn't produce duplicates.
+ * (This is to stay backward compatible.)
  */
 export class LanguageFactory {
 
@@ -32,44 +38,60 @@ export class LanguageFactory {
     }
 
 
-    // TODO  also take care of containment immediately? (then most calls to .having<X> would be unnecessary/wrong)
-
     annotation(name: string, extends_?: SingleRef<Annotation>) {
-        return new Annotation(this.language, name, this.key(this.language.name, name), this.id(this.language.name, name), extends_)
+        const annotation = new Annotation(this.language, name, this.key(this.language.name, name), this.id(this.language.name, name), extends_)
+        this.language.havingEntities(annotation)
+        return annotation
     }
 
     concept(name: string, abstract: boolean, extends_?: SingleRef<Concept>) {
-        return new Concept(this.language, name, this.key(this.language.name, name), this.id(this.language.name, name), abstract, extends_)
+        const concept = new Concept(this.language, name, this.key(this.language.name, name), this.id(this.language.name, name), abstract, extends_)
+        this.language.havingEntities(concept)
+        return concept
     }
 
     interface(name: string) {
-        return new Interface(this.language, name, this.key(this.language.name, name), this.id(this.language.name, name))
+        const intface = new Interface(this.language, name, this.key(this.language.name, name), this.id(this.language.name, name))
+        this.language.havingEntities(intface)
+        return intface
     }
 
     enumeration(name: string) {
-        return new Enumeration(this.language, name, this.key(this.language.name, name), this.id(this.language.name, name))
+        const enumeration = new Enumeration(this.language, name, this.key(this.language.name, name), this.id(this.language.name, name))
+        this.language.havingEntities(enumeration)
+        return enumeration
     }
 
     primitiveType(name: string) {
-        return new PrimitiveType(this.language, name, this.key(this.language.name, name), this.id(this.language.name, name))
+        const primitiveType = new PrimitiveType(this.language, name, this.key(this.language.name, name), this.id(this.language.name, name))
+        this.language.havingEntities(primitiveType)
+        return primitiveType
     }
 
 
     containment(classifier: Classifier, name: string) {
-        return new Containment(classifier, name, this.key(this.language.name, classifier.name, name), this.id(this.language.name, classifier.name, name))
+        const containment = new Containment(classifier, name, this.key(this.language.name, classifier.name, name), this.id(this.language.name, classifier.name, name))
+        classifier.havingFeatures(containment)
+        return containment
     }
 
     property(classifier: Classifier, name: string) {
-        return new Property(classifier, name, this.key(this.language.name, classifier.name, name), this.id(this.language.name, classifier.name, name))
+        const property = new Property(classifier, name, this.key(this.language.name, classifier.name, name), this.id(this.language.name, classifier.name, name))
+        classifier.havingFeatures(property)
+        return property
     }
 
     reference(classifier: Classifier, name: string) {
-        return new Reference(classifier, name, this.key(this.language.name, classifier.name, name), this.id(this.language.name, classifier.name, name))
+        const reference = new Reference(classifier, name, this.key(this.language.name, classifier.name, name), this.id(this.language.name, classifier.name, name))
+        classifier.havingFeatures(reference)
+        return reference
     }
 
 
     enumerationLiteral(enumeration: Enumeration, name: string) {
-        return new EnumerationLiteral(enumeration, name, this.key(this.language.name, enumeration.name, name), this.id(this.language.name, enumeration.name, name))
+        const enumerationLiteral = new EnumerationLiteral(enumeration, name, this.key(this.language.name, enumeration.name, name), this.id(this.language.name, enumeration.name, name))
+        enumeration.havingLiterals(enumerationLiteral)
+        return enumerationLiteral
     }
 
 }

--- a/packages/core/src/m3/functions.ts
+++ b/packages/core/src/m3/functions.ts
@@ -202,7 +202,7 @@ const inheritsFrom = (classifier: Classifier): Classifier[] => {
     if (classifier instanceof Interface) {
         return classifier.extends
     }
-    throw new Error(`concept type ${typeof classifier} not handled`)
+    throw new Error(`classifier type ${typeof classifier} not handled`)
 }
 
 /**

--- a/packages/core/src/m3/lioncore.ts
+++ b/packages/core/src/m3/lioncore.ts
@@ -39,26 +39,16 @@ const ikeyed = factory.interface("IKeyed")
 const ikeyed_key = factory.property(ikeyed, "key")
     .ofType(stringDatatype)
 
-ikeyed.havingFeatures(ikeyed_key)
-
 
 const feature = factory.concept("Feature", true).implementing(ikeyed)
 
 const feature_optional = factory.property(feature, "optional")
     .ofType(booleanDatatype)
 
-feature.havingFeatures(
-    feature_optional
-)
-
 
 const property = factory.concept("Property", false, feature)
 
 const property_type = factory.reference(property, "type")
-
-property.havingFeatures(
-    property_type
-)
 
 
 const link = factory.concept("Link", true, feature)
@@ -67,11 +57,6 @@ const link_multiple = factory.property(link, "multiple")
     .ofType(booleanDatatype)
 
 const link_type = factory.reference(link, "type")
-
-link.havingFeatures(
-    link_multiple,
-    link_type
-)
 
 
 const containment = factory.concept("Containment", false, link)
@@ -91,10 +76,6 @@ const classifier_features = factory.containment(classifier, "features")
     .isMultiple()
     .ofType(feature)
 
-classifier.havingFeatures(
-    classifier_features
-)
-
 link_type.ofType(classifier)
 
 
@@ -111,12 +92,6 @@ const annotation_extends = factory.reference(annotation, "extends")
 const annotation_implements = factory.reference(annotation, "implements")
     .isMultiple()
     .isOptional()
-
-annotation.havingFeatures(
-    annotation_annotates,
-    annotation_extends,
-    annotation_implements
-)
 
 
 const concept = factory.concept("Concept", false, classifier)
@@ -135,13 +110,6 @@ const concept_implements = factory.reference(concept, "implements")
     .isOptional()
     .isMultiple()
 
-concept.havingFeatures(
-    concept_abstract,
-    concept_partition,
-    concept_extends,
-    concept_implements
-)
-
 
 const interface_ = factory.concept("Interface", false, classifier)
 
@@ -149,8 +117,6 @@ const interface_extends = factory.reference(interface_, "extends")
     .isOptional()
     .isMultiple()
     .ofType(interface_)
-
-interface_.havingFeatures(interface_extends)
 
 annotation_implements.ofType(interface_)
 concept_implements.ofType(interface_)
@@ -169,8 +135,6 @@ const enumeration = factory.concept("Enumeration", false, dataType)
 const enumeration_literals = factory.containment(enumeration, "literals")
     .isMultiple()
     .isOptional()
-
-enumeration.havingFeatures(enumeration_literals)
 
 
 const enumerationLiteral = factory.concept("EnumerationLiteral", false)
@@ -195,28 +159,6 @@ const language_dependsOn = factory.reference(language, "dependsOn")
     .isOptional()
     .isMultiple()
     .ofType(language)
-
-language.havingFeatures(language_version, language_entities, language_dependsOn)
-
-
-lioncore.havingEntities(
-    ikeyed,
-    feature,
-    property,
-    link,
-    containment,
-    reference,
-    languageEntity,
-    classifier,
-    annotation,
-    concept,
-    interface_,
-    dataType,
-    primitiveType,
-    enumeration,
-    enumerationLiteral,
-    language
-)
 
 
 export const metaConcepts = {

--- a/packages/core/src/m3/types.ts
+++ b/packages/core/src/m3/types.ts
@@ -141,8 +141,7 @@ abstract class LanguageEntity extends M3Node {
 abstract class Classifier extends LanguageEntity {
     features: Feature[] = [] // (containment)
     havingFeatures(...features: Feature[]) {
-        // TODO  check actual types of features, or use type shapes/interfaces
-        this.features.push(...features)
+        this.features.push(...features.filter((feature) => this.features.indexOf(feature) < 0))
         return this
     }
     metaPointer(): MetaPointer {
@@ -228,7 +227,7 @@ class Enumeration extends Datatype {
     }
     literals: EnumerationLiteral[] = [] // (containment)
     havingLiterals(...literals: EnumerationLiteral[]) {
-        this.literals.push(...literals)
+        this.literals.push(...literals.filter((literal) => this.literals.indexOf(literal) < 0))
         return this
     }
 }
@@ -257,18 +256,13 @@ class Language extends M3Node {
         super(id, name, key)
         this.version = version
     }
-    havingEntities(...elements: LanguageEntity[]): Language {
-        const nonLanguageElements = elements.filter((element) => !(element instanceof LanguageEntity))
-        if (nonLanguageElements.length > 0) {
-            throw Error(`trying to add non-LanguageElements to Language: ${nonLanguageElements.map((node) => `<${node.constructor.name}>"${node.name}"`).join(", ")}`)
-        }
-        this.entities.push(...elements)
+    havingEntities(...entities: LanguageEntity[]): Language {
+        this.entities.push(...entities.filter((entity) => this.entities.indexOf(entity) < 0))
         return this
     }
-    dependingOn(...metamodels: Language[]): Language {
-        // TODO  check actual types of metamodels, or use type shapes/interfaces
+    dependingOn(...languages: Language[]): Language {
         this.dependsOn.push(
-            ...metamodels
+            ...languages
                 .filter((language) => language.key !== lioncoreBuiltinsKey)
         )
         return this

--- a/packages/core/src/serializer.ts
+++ b/packages/core/src/serializer.ts
@@ -97,7 +97,7 @@ export const serializeNodes = <NT extends Node>(
                 key: feature.key
             }
             if (feature instanceof Property) {
-                if (value === undefined) {
+                if (value === undefined && !serializeEmptyValues) {
                     // for immediate backward compatibility: skip empty property values regardless of options?.skipEmptyValues
                     return
                 }
@@ -108,16 +108,13 @@ export const serializeNodes = <NT extends Node>(
                     }
                     if (feature.type instanceof Enumeration) {
                         return extractionFacade.enumerationLiteralFrom(value, feature.type)?.key
-                            ?? null // (undefined -> null)
                     }
-                    return null
+                    return undefined
                 })()
-                if (encodedValue !== null) {
-                    serializedNode.properties.push({
-                        property: featureMetaPointer,
-                        value: encodedValue as string
-                    })
-                }
+                serializedNode.properties.push({
+                    property: featureMetaPointer,
+                    value: (encodedValue as string) ?? null // (undefined -> null)
+                })
                 return
             }
             if (feature instanceof Containment) {

--- a/packages/test/src/infer-languages.test.ts
+++ b/packages/test/src/infer-languages.test.ts
@@ -1,54 +1,53 @@
-import { deepEqual } from "assert"
-import { LanguageEntity, serializeLanguages, serializeNodes } from "@lionweb/core"
-import { inferLanguagesFromSerializationChunk, deriveLikelyPropertyName } from "@lionweb/utilities"
+import {deepEqual, equal} from "assert"
+import {serializeLanguages, serializeNodes} from "@lionweb/core"
+import {
+    deriveLikelyPropertyName,
+    inferLanguagesFromSerializationChunk,
+    sortedSerializationChunk
+} from "@lionweb/utilities"
 
-import { libraryExtractionFacade, libraryModel } from "./instances/library.js"
-import { minimalLibraryLanguage } from "./languages/minimal-library.js"
-import { multiExtractionFacade, multiModel } from "./instances/multi.js"
-import { multiLanguage } from "./languages/multi.js"
+import {libraryExtractionFacade, libraryModel} from "./instances/library.js"
+import {minimalLibraryLanguage} from "./languages/minimal-library.js"
+import {multiExtractionFacade, multiModel} from "./instances/multi.js"
+import {multiLanguage} from "./languages/multi.js"
+
 
 describe("inferLanguagesFromChunk", () => {
+
     it("should correctly infer the minimal library language from the instance", () => {
         const serializationChunk = serializeNodes(libraryModel, libraryExtractionFacade)
 
         const languages = inferLanguagesFromSerializationChunk(serializationChunk)
-        deepEqual(languages.length, 1)
+        equal(languages.length, 1)
         const inferredLanguage = languages[0]
 
-        // Sort language entities to be able to compare them
-        inferredLanguage.entities.sort(compare)
-        minimalLibraryLanguage.entities.sort(compare)
-
-        deepEqual(serializeLanguages(inferredLanguage), serializeLanguages(minimalLibraryLanguage))
+        deepEqual(sortedSerializationChunk(serializeLanguages(inferredLanguage)), sortedSerializationChunk(serializeLanguages(minimalLibraryLanguage)))
     })
 
     it("should correctly infer the multi language from the instance", () => {
         const serializationChunk = serializeNodes(multiModel, multiExtractionFacade)
 
         const languages = inferLanguagesFromSerializationChunk(serializationChunk)
-        deepEqual(languages.length, 2)
+        equal(languages.length, 2)
         const inferredMultiLanguage = languages[0]
         const inferredLibraryLanguage = languages[1]
 
-        // We can't infer the language dependency
+        // (we can't infer the language dependency)
         inferredMultiLanguage.dependingOn(inferredLibraryLanguage)
 
-        // Sort language entities to be able to compare them
-        inferredLibraryLanguage.entities.sort(compare)
-        minimalLibraryLanguage.entities.sort(compare)
-
-        deepEqual(serializeLanguages(inferredLibraryLanguage), serializeLanguages(minimalLibraryLanguage))
-        deepEqual(serializeLanguages(inferredMultiLanguage), serializeLanguages(multiLanguage))
+        deepEqual(sortedSerializationChunk(serializeLanguages(inferredLibraryLanguage)), sortedSerializationChunk(serializeLanguages(minimalLibraryLanguage)))
+        deepEqual(sortedSerializationChunk(serializeLanguages(inferredMultiLanguage)), sortedSerializationChunk(serializeLanguages(multiLanguage)))
     })
+
 })
 
 describe("deriveLikelyPropertyName", () => {
+
     describe("for supported formats", () => {
         ["-", "_"].forEach(separator => {
             const propertyKey = ["languageKey", "classifierKey", "propertyKey"].join(separator)
             it(`should derive the property name when using separator '${separator}'`, () => {
-                const result = deriveLikelyPropertyName(propertyKey)
-                deepEqual(result, "propertyKey")
+                equal(deriveLikelyPropertyName(propertyKey), "propertyKey")
             })
         })
     })
@@ -56,18 +55,9 @@ describe("deriveLikelyPropertyName", () => {
     describe("for unsupported formats", () => {
         const propertyKey = "classifierKey$propertyKey"
         it("should return the entire key", () => {
-            const result = deriveLikelyPropertyName(propertyKey)
-            deepEqual(result, propertyKey)
+            equal(deriveLikelyPropertyName(propertyKey), propertyKey)
         })
     })
+
 })
 
-function compare(a: LanguageEntity, b: LanguageEntity) {
-    if (a.id < b.id) {
-        return -1
-    }
-    if (a.id > b.id) {
-        return 1
-    }
-    return 0
-}

--- a/packages/test/src/languages/generic.ts
+++ b/packages/test/src/languages/generic.ts
@@ -15,10 +15,8 @@ export const AnotherConcept = factory.concept("AnotherConcept", false)
 
 export const SomeConcept_ref = factory.reference(SomeConcept, "ref").ofType(AnotherConcept).isOptional()
 export const SomeConcept_refs = factory.reference(SomeConcept, "refs").ofType(AnotherConcept).isMultiple()
-SomeConcept.havingFeatures(SomeConcept_ref, SomeConcept_refs)
 
 export const SomeAnnotation = factory.annotation("SomeAnnotation")
 SomeAnnotation.annotates = AnotherConcept
 export const SomeAnnotation_ref = factory.reference(SomeAnnotation, "ref").ofType(SomeConcept)
-SomeAnnotation.havingFeatures(SomeAnnotation_ref)
 

--- a/packages/test/src/languages/library.ts
+++ b/packages/test/src/languages/library.ts
@@ -12,44 +12,28 @@ export const libraryLanguage = factory.language
 
 const {integerDatatype, stringDatatype} = builtinPrimitives
 
-export const library = factory.concept("Library", false)
 const book = factory.concept("Book", false)
+const bookType = factory.enumeration("BookType")
+factory.enumerationLiteral(bookType, "Normal")
+factory.enumerationLiteral(bookType, "Special")
+
+export const library = factory.concept("Library", false)
 const writer = factory.concept("Writer", false)
 const guideBookWriter = factory.concept("GuideBookWriter", false, writer)
 const specialistBookWriter = factory.concept("SpecialistBookWriter", false, writer)
-const bookType = factory.enumeration("BookType")
-bookType.havingLiterals(
-        factory.enumerationLiteral(bookType, "Normal"),
-        factory.enumerationLiteral(bookType, "Special")
-    )
 
-const library_name = factory.property(library, "name").ofType(stringDatatype).havingKey("library_Library_name")
-const library_books = factory.containment(library, "books").ofType(book).isMultiple()
-library.havingFeatures(library_name, library_books)
+factory.property(library, "name").ofType(stringDatatype).havingKey("library_Library_name")
+factory.containment(library, "books").ofType(book).isMultiple()
 
-const book_title = factory.property(book, "title").ofType(stringDatatype)
-const book_pages = factory.property(book, "pages").ofType(integerDatatype)
-const book_author = factory.reference(book, "author").ofType(writer)
-const book_type = factory.property(book, "type").ofType(bookType).isOptional()
-book.havingFeatures(book_title, book_pages, book_author, book_type)
+factory.property(book, "title").ofType(stringDatatype)
+factory.property(book, "pages").ofType(integerDatatype)
+factory.reference(book, "author").ofType(writer)
+factory.property(book, "type").ofType(bookType).isOptional()
 
-const writer_name = factory.property(writer, "name").ofType(stringDatatype).havingKey("library_Writer_name")
-writer.havingFeatures(writer_name)
+factory.property(writer, "name").ofType(stringDatatype).havingKey("library_Writer_name")
 // Note: writers are _not_ contained in the library (node) itself, so are separate nodes.
 
-const guideBookWriter_countries = factory.property(guideBookWriter, "countries").ofType(stringDatatype)
-guideBookWriter.havingFeatures(guideBookWriter_countries)
+factory.property(guideBookWriter, "countries").ofType(stringDatatype)
 
-const specialistBookWriter_subject = factory.property(specialistBookWriter, "subject").ofType(stringDatatype)
-specialistBookWriter.havingFeatures(specialistBookWriter_subject)
-
-
-libraryLanguage.havingEntities(
-    book,
-    bookType,
-    library,
-    writer,
-    guideBookWriter,
-    specialistBookWriter
-)
+factory.property(specialistBookWriter, "subject").ofType(stringDatatype)
 

--- a/packages/test/src/languages/libraryWithDates.ts
+++ b/packages/test/src/languages/libraryWithDates.ts
@@ -18,41 +18,23 @@ const writer = factory.concept("Writer", false)
 const guideBookWriter = factory.concept("GuideBookWriter", false, writer)
 const specialistBookWriter = factory.concept("SpecialistBookWriter", false, writer)
 const bookType = factory.enumeration("BookType")
-bookType.havingLiterals(
-        factory.enumerationLiteral(bookType, "Normal"),
-        factory.enumerationLiteral(bookType, "Special")
-    )
+factory.enumerationLiteral(bookType, "Normal")
+factory.enumerationLiteral(bookType, "Special")
 export const dateDatatype = factory.primitiveType("Date")
 
-const library_name = factory.property(libraryWithDates, "name").ofType(stringDatatype).havingKey("library_Library_name")
-const library_creationDate = factory.property(libraryWithDates, "creationDate").ofType(dateDatatype).havingKey("library_Library_creationDate")
-const library_books = factory.containment(libraryWithDates, "books").ofType(book).isMultiple()
-libraryWithDates.havingFeatures(library_name, library_books, library_creationDate)
+factory.property(libraryWithDates, "name").ofType(stringDatatype).havingKey("library_Library_name")
+factory.property(libraryWithDates, "creationDate").ofType(dateDatatype).havingKey("library_Library_creationDate")
+factory.containment(libraryWithDates, "books").ofType(book).isMultiple()
 
-const book_title = factory.property(book, "title").ofType(stringDatatype)
-const book_pages = factory.property(book, "pages").ofType(integerDatatype)
-const book_author = factory.reference(book, "author").ofType(writer)
-const book_type = factory.property(book, "type").ofType(bookType).isOptional()
-book.havingFeatures(book_title, book_pages, book_author, book_type)
+factory.property(book, "title").ofType(stringDatatype)
+factory.property(book, "pages").ofType(integerDatatype)
+factory.reference(book, "author").ofType(writer)
+factory.property(book, "type").ofType(bookType).isOptional()
 
-const writer_name = factory.property(writer, "name").ofType(stringDatatype).havingKey("library_Writer_name")
-writer.havingFeatures(writer_name)
+factory.property(writer, "name").ofType(stringDatatype).havingKey("library_Writer_name")
 // Note: writers are _not_ contained in the library (node) itself, so are separate nodes.
 
-const guideBookWriter_countries = factory.property(guideBookWriter, "countries").ofType(stringDatatype)
-guideBookWriter.havingFeatures(guideBookWriter_countries)
+factory.property(guideBookWriter, "countries").ofType(stringDatatype)
 
-const specialistBookWriter_subject = factory.property(specialistBookWriter, "subject").ofType(stringDatatype)
-specialistBookWriter.havingFeatures(specialistBookWriter_subject)
-
-
-libraryWithDatesLanguage.havingEntities(
-    book,
-    bookType,
-    libraryWithDates,
-    dateDatatype,
-    writer,
-    guideBookWriter,
-    specialistBookWriter
-)
+factory.property(specialistBookWriter, "subject").ofType(stringDatatype)
 

--- a/packages/test/src/languages/meta.ts
+++ b/packages/test/src/languages/meta.ts
@@ -13,19 +13,15 @@ const factory = new LanguageFactory(
  */
 export const metaLanguage = factory.language
 
-const anAnnotation = factory.annotation("AnAnnotation")
+factory.annotation("AnAnnotation")
 
 const aConcept = factory.concept("AConcept", false)
-const aProperty = factory.property(aConcept, "aProperty").ofType(builtinPrimitives.jsonDatatype)
-const aContainment = factory.containment(aConcept, "aContainment").ofType(aConcept)
-const aReference = factory.reference(aConcept, "aReference").ofType(aConcept)
-aConcept.havingFeatures(aProperty, aContainment, aReference)
+factory.property(aConcept, "aProperty").ofType(builtinPrimitives.jsonDatatype)
+factory.containment(aConcept, "aContainment").ofType(aConcept)
+factory.reference(aConcept, "aReference").ofType(aConcept)
 
 const anEnumeration = factory.enumeration("AnEnumeration")
-const anEnumerationLiteral = factory.enumerationLiteral(anEnumeration, "anEnumerationLiteral")
-anEnumeration.havingLiterals(anEnumerationLiteral)
+factory.enumerationLiteral(anEnumeration, "anEnumerationLiteral")
 
-const anInterface = factory.interface("AnInterface")
-
-metaLanguage.havingEntities(anAnnotation, aConcept, anEnumeration, anInterface)
+factory.interface("AnInterface")
 

--- a/packages/test/src/languages/shapes.ts
+++ b/packages/test/src/languages/shapes.ts
@@ -10,28 +10,22 @@ const factory = new LanguageFactory(
 )
 export const shapesLanguage = factory.language
 
+export const Coord = factory.concept("Coord", false)
 const Geometry = factory.concept("Geometry", false)
 const Shape = factory.concept("Shape", true).implementing(builtinClassifiers.inamed)
 export const Circle = factory.concept("Circle", false, Shape)
 const Line = factory.concept("Line", false, Shape)
-export const Coord = factory.concept("Coord", false)
 
-const GeometryShapes = factory.containment(Geometry, "shapes").ofType(Shape).isMultiple().isOptional()
-const LineStart = factory.containment(Line, "start").ofType(Coord)
-const LineEnd = factory.containment(Line, "end").ofType(Coord)
-const CircleCenter = factory.containment(Circle, "center").ofType(Coord)
-const CircleRadius = factory.property(Circle, "r").ofType(builtinPrimitives.integerDatatype)
+factory.containment(Geometry, "shapes").ofType(Shape).isMultiple().isOptional()
+factory.containment(Line, "start").ofType(Coord)
+factory.containment(Line, "end").ofType(Coord)
+factory.property(Circle, "r").ofType(builtinPrimitives.integerDatatype)
+factory.containment(Circle, "center").ofType(Coord)
 
-const CoordX = factory.property(Coord, "x").ofType(builtinPrimitives.integerDatatype)
-const CoordY = factory.property(Coord, "y").ofType(builtinPrimitives.integerDatatype)
-const CoordZ = factory.property(Coord, "z").ofType(builtinPrimitives.integerDatatype)
-
-Geometry.havingFeatures(GeometryShapes)
-Circle.havingFeatures(CircleRadius, CircleCenter)
-Line.havingFeatures(LineStart, LineEnd)
-Coord.havingFeatures(CoordX, CoordY, CoordZ)
+factory.property(Coord, "x").ofType(builtinPrimitives.integerDatatype)
+factory.property(Coord, "y").ofType(builtinPrimitives.integerDatatype)
+factory.property(Coord, "z").ofType(builtinPrimitives.integerDatatype)
 
 export const Annotated = factory.annotation("Annotated").annotating(Shape)
 
-shapesLanguage.havingEntities(Coord, Geometry, Shape, Circle, Line, Annotated)
 

--- a/packages/test/src/m3/constraints.test.ts
+++ b/packages/test/src/m3/constraints.test.ts
@@ -157,7 +157,6 @@ describe("Concept constraints", () => {
         cis[2].extends.push(cis[1])
         cis[1].extends.push(cis[0])
         cis[0].extends.push(cis[2])
-        language.entities.push(...cis)
 
         const issues = issuesLanguage(language)
         deepEqual(issues.length, 3)
@@ -170,7 +169,6 @@ describe("Concept constraints", () => {
         const {language} = factory
         const ci = factory.interface("foo")
         ci.extends.push(ci)
-        language.entities.push(ci)
 
         const issues = issuesLanguage(language)
         deepEqual(issues.length, 1)

--- a/packages/test/src/m3/diagrams/diagrams.test.ts
+++ b/packages/test/src/m3/diagrams/diagrams.test.ts
@@ -36,19 +36,13 @@ const testLanguage = (() => {
     const primitive1 = factory.primitiveType("CustomPrimitive")
 
     const concept1 = factory.concept("Concept1", false, builtinClassifiers.node)
-    concept1.havingFeatures(
-        factory.property(concept1, "prop1").isOptional().ofType(primitive1),
-        factory.reference(concept1, "selfRefs").isMultiple().isOptional().ofType(concept1),
-        factory.reference(concept1, "nodeTargets").ofType(builtinClassifiers.node)
-    )
+    factory.property(concept1, "prop1").isOptional().ofType(primitive1)
+    factory.reference(concept1, "selfRefs").isMultiple().isOptional().ofType(concept1)
+    factory.reference(concept1, "nodeTargets").ofType(builtinClassifiers.node)
 
     const interface1 = factory.interface("Interface1")
-
     const annotation1 = factory.annotation("Annotation1").annotating(builtinClassifiers.node)
-
-    const annotation2 = factory.annotation("Annotation2", annotation1).implementing(interface1)
-
-    factory.language.havingEntities(primitive1, concept1, interface1, annotation1, annotation2)
+    factory.annotation("Annotation2", annotation1).implementing(interface1)
 
     return factory.language
 })()

--- a/packages/test/src/m3/key-generation.test.ts
+++ b/packages/test/src/m3/key-generation.test.ts
@@ -16,12 +16,10 @@ describe("key generation", () => {
         )
 
         const form = factory.concept("Form", false)
-        factory.language.havingEntities(form)
 
         deepEqual(form.key, "FormLanguage-Form")
 
         const size = factory.property(form, "size").ofType(builtinPrimitives.integerDatatype)
-        form.havingFeatures(size)
 
         deepEqual(size.key, "FormLanguage-Form-size")
     })

--- a/packages/test/src/m3/serializer.test.ts
+++ b/packages/test/src/m3/serializer.test.ts
@@ -1,0 +1,20 @@
+import {expect} from "chai"
+
+import {concatenator, LanguageFactory, lastOf, serializeLanguages} from "@lionweb/core"
+
+
+describe("serialization of a language", () => {
+
+    it("doesn't fail when an annotation doesn't specify what it annotates", () => {
+        const factory = new LanguageFactory("annotation-language", "0", concatenator("-"), lastOf)
+        factory.annotation("annotation")
+        const serializationChunk = serializeLanguages(factory.language)
+        const annotationNode = serializationChunk.nodes.find((node) => node.id === "annotation-language-annotation")
+        expect(annotationNode).to.not.be.undefined
+        const serializedReference = annotationNode!.references.find((serRef) => serRef.reference.key === "Annotation-annotates")
+        expect(serializedReference).to.not.be.undefined
+        expect(serializedReference!.targets).to.eql([])
+    })
+
+})
+

--- a/packages/test/src/m3/types.test.ts
+++ b/packages/test/src/m3/types.test.ts
@@ -1,39 +1,31 @@
-// const { throws } = require("chai").assert
-// import {LanguageFactory} from "../../src-pkg/m3/factory.js"
-// import {builtinPrimitives} from "../../src-pkg/m3/builtins.js"
+import {assert} from "chai"
+const {equal} = assert
 
-
-/*
- * The following typechecks because all classes are effectively one type "class" as TypeScript is concerned.
- */
-class A {
-    with(_: _B) {}
-}
-class _B {}
-const a = new A()
-a.with(a)   // would be nice if this produced a compiler error!
-/*
- * This means that we have to check arguments of a class-type "manually".
- */
+import {concatenator, LanguageFactory, lastOf} from "@lionweb/core"
 
 
 describe("M3 types", () => {
 
-    /*
-    it("adding non-language elements to a language should fail", () => {
-        const factory = new LanguageFactory("TestLanguage", "0")
+    it("factory performs auto-containment, but also prevents duplication", () => {
+        const factory = new LanguageFactory("TestLanguage", "0", concatenator("-"), lastOf)
         const {language} = factory
+
         const concept = factory.concept("Concept", false)
-        const property = factory.property(concept, "property").ofType(builtinPrimitives.intDatatype)
-        factory.language.havingEntities(concept)
-        // TODO  understand why the following fails to compile after the addition of a getter "language" to LanguageEntity
-        throws(() => {
-            language.havingEntities(property),
-            Error,
-            `trying to add non-LanguageElements to Language: <Property>"property"`
-        })
+        equal(language.entities.length, 1)
+        language.havingEntities(concept)
+        equal(language.entities.length, 1)
+
+        const containment = factory.containment(concept, "containment")
+        equal(concept.features.length, 1)
+        concept.havingFeatures(containment)
+        equal(concept.features.length, 1)
+
+        const enumeration = factory.enumeration("enumeration")
+        const literal = factory.enumerationLiteral(enumeration, "literal")
+        equal(enumeration.literals.length, 1)
+        enumeration.havingLiterals(literal)
+        equal(enumeration.literals.length, 1)
     })
-     */
 
 })
 

--- a/packages/test/src/serializer.test.ts
+++ b/packages/test/src/serializer.test.ts
@@ -268,7 +268,40 @@ describe("serialization of empty (unset) values", () => {
                         version: "0",
                         key: "concept"
                     },
-                    properties: [],
+                    properties: [
+                        {
+                            property: {
+                                key: "stringProperty",
+                                language: "serialization-language",
+                                version: "0"
+                            },
+                            value: null
+                        },
+                        {
+                            property: {
+                                key: "integerProperty",
+                                language: "serialization-language",
+                                version: "0"
+                            },
+                            value: null
+                        },
+                        {
+                            property: {
+                                key: "booleanProperty",
+                                language: "serialization-language",
+                                version: "0"
+                            },
+                            value: null
+                        },
+                        {
+                            property: {
+                                key: "enumProperty",
+                                language: "serialization-language",
+                                version: "0"
+                            },
+                            value: null
+                        }
+                    ],
                     containments: [
                         {
                             containment: {

--- a/packages/test/src/serializer.test.ts
+++ b/packages/test/src/serializer.test.ts
@@ -310,9 +310,9 @@ describe("serialization of empty (unset) values", () => {
                 }
             ]
         }
-        const actualSerializationChunk = serializeNodes([node], dynamicExtractionFacade)
+        const actualSerializationChunk = serializeNodes([node], dynamicExtractionFacade)    // (serializeEmptyValues has true as default)
         expect(actualSerializationChunk).to.eql(expectedSerializationChunk)
-        const usingExplicitOption = serializeNodes([node], dynamicExtractionFacade, { skipEmptyValues: false })
+        const usingExplicitOption = serializeNodes([node], dynamicExtractionFacade, { serializeEmptyValues: true })
         expect(usingExplicitOption).to.eql(expectedSerializationChunk)
     })
 
@@ -341,7 +341,7 @@ describe("serialization of empty (unset) values", () => {
                 }
             ]
         }
-        const actualSerializationChunk = serializeNodes([node], dynamicExtractionFacade, { skipEmptyValues: true })
+        const actualSerializationChunk = serializeNodes([node], dynamicExtractionFacade, { serializeEmptyValues: false })
         expect(actualSerializationChunk).to.eql(expectedSerializationChunk)
     })
 


### PR DESCRIPTION
(Includes make language factory auto-containing, for its own convenience. This is why I killed PR #197.)

**Note** that commits are atomic, so reviewing per commit is entirely sensible!