### PR TITLE
Fix `messageKind` field for request messages of queries to *not* have the `Request` suffix

### DIFF
--- a/packages/delta-protocol-client/CHANGELOG.md
+++ b/packages/delta-protocol-client/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.0 — not yet released
 
 * Rework the `LionWebClient` class to use the new `Forest` class from the `class-core` package.
+* Fix `messageKind` field for request messages of queries to *not* have the "`Request`" suffix.
 
 
 ## 0.7.1

--- a/packages/delta-protocol-client/src/client.ts
+++ b/packages/delta-protocol-client/src/client.ts
@@ -205,7 +205,7 @@ export class LionWebClient {
 
     async subscribeToChangingPartitions(queryId: LionWebId, parameters: SubscribeToPartitionChangesParameters): Promise<void> {
         await this.makeQuery({
-            messageKind: "SubscribeToChangingPartitionsRequest",
+            messageKind: "SubscribeToChangingPartitions",
             queryId,
             ...parameters,
             protocolMessages: []
@@ -214,7 +214,7 @@ export class LionWebClient {
 
     async subscribeToPartitionContents(queryId: LionWebId, partition: LionWebId): Promise<LionWebJsonChunk> {   // TODO  already deserialize, because we've got everything we need
         const response = await this.makeQuery({
-            messageKind: "SubscribeToPartitionContentsRequest",
+            messageKind: "SubscribeToPartitionContents",
             queryId,
             partition,
             protocolMessages: []
@@ -224,7 +224,7 @@ export class LionWebClient {
 
     async unsubscribeFromPartitionContents(queryId: LionWebId, partition: LionWebId): Promise<void> {
         await this.makeQuery({
-            messageKind: "UnsubscribeFromPartitionContentsRequest",
+            messageKind: "UnsubscribeFromPartitionContents",
             queryId,
             partition,
             protocolMessages: []
@@ -236,7 +236,7 @@ export class LionWebClient {
             return Promise.reject(new Error(`can't sign on after having signed off`))
         }
         const response = await this.makeQuery({
-            messageKind: "SignOnRequest",
+            messageKind: "SignOn",
             queryId,
             repositoryId,
             deltaProtocolVersion: "2025.1",
@@ -248,7 +248,7 @@ export class LionWebClient {
 
     async signOff(queryId: LionWebId): Promise<void> {
         await this.makeQuery({
-            messageKind: "SignOffRequest",
+            messageKind: "SignOff",
             queryId,
             protocolMessages: []
         } as SignOffRequest)
@@ -258,7 +258,7 @@ export class LionWebClient {
 
     async reconnect(queryId: LionWebId, participationId: LionWebId, lastReceivedSequenceNumber: number): Promise<void> {
         const response = await this.makeQuery({
-            messageKind: "ReconnectRequest",
+            messageKind: "Reconnect",
             queryId,
             participationId,
             lastReceivedSequenceNumber,
@@ -270,7 +270,7 @@ export class LionWebClient {
 
     async getAvailableIds(queryId: LionWebId, count: number): Promise<LionWebId[]> {
         const response = await this.makeQuery({
-            messageKind: "GetAvailableIdsRequest",
+            messageKind: "GetAvailableIds",
             queryId,
             count,
             protocolMessages: []
@@ -280,7 +280,7 @@ export class LionWebClient {
 
     async listPartitions(queryId: LionWebId): Promise<LionWebJsonChunk> {
         const response = await this.makeQuery({
-            messageKind: "ListPartitionsRequest",
+            messageKind: "ListPartitions",
             queryId,
             protocolMessages: []
         } as ListPartitionsRequest) as ListPartitionsResponse

--- a/packages/delta-protocol-common/CHANGELOG.md
+++ b/packages/delta-protocol-common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.8.0 — not yet released
+
+* Fix `messageKind` field for request messages of queries to *not* have the "`Request`" suffix.
+
+
 ## 0.7.2
 
 * Use the `propertyValueSerializerWith` function from the `class-core` package for the `deltaToCommandTranslator` and `deltaToEventTranslator` functions.

--- a/packages/delta-protocol-common/src/payload/query-types.ts
+++ b/packages/delta-protocol-common/src/payload/query-types.ts
@@ -36,7 +36,7 @@ export interface SubscribeToPartitionChangesParameters {
 }
 
 export interface SubscribeToChangingPartitionsRequest extends QueryMessage, SubscribeToPartitionChangesParameters {
-    messageKind: "SubscribeToChangingPartitionsRequest"
+    messageKind: "SubscribeToChangingPartitions"
 }
 
 export interface SubscribeToChangingPartitionsResponse extends QueryMessage {
@@ -45,7 +45,7 @@ export interface SubscribeToChangingPartitionsResponse extends QueryMessage {
 
 
 export interface SubscribeToPartitionContentsRequest extends QueryMessage {
-    messageKind: "SubscribeToPartitionContentsRequest"
+    messageKind: "SubscribeToPartitionContents"
     partition: LionWebId
 }
 
@@ -56,7 +56,7 @@ export interface SubscribeToPartitionContentsResponse extends QueryMessage {
 
 
 export interface UnsubscribeFromPartitionContentsRequest extends QueryMessage {
-    messageKind: "UnsubscribeFromPartitionContentsRequest"
+    messageKind: "UnsubscribeFromPartitionContents"
     partition: LionWebId
 }
 
@@ -66,7 +66,7 @@ export interface UnsubscribeFromPartitionContentsResponse extends QueryMessage {
 
 
 export interface SignOnRequest extends QueryMessage {
-    messageKind: "SignOnRequest"
+    messageKind: "SignOn"
     deltaProtocolVersion: "2025.1"
     clientId: LionWebId
     repositoryId: LionWebId
@@ -79,7 +79,7 @@ export interface SignOnResponse extends QueryMessage {
 
 
 export interface SignOffRequest extends QueryMessage {
-    messageKind: "SignOffRequest"
+    messageKind: "SignOff"
 }
 
 export interface SignOffResponse extends QueryMessage {
@@ -88,7 +88,7 @@ export interface SignOffResponse extends QueryMessage {
 
 
 export interface ReconnectRequest extends QueryMessage {
-    messageKind: "ReconnectRequest"
+    messageKind: "Reconnect"
     participationId: LionWebId
     lastReceivedSequenceNumber: number
 }
@@ -100,7 +100,7 @@ export interface ReconnectResponse extends QueryMessage {
 
 
 export interface GetAvailableIdsRequest extends QueryMessage {
-    messageKind: "GetAvailableIdsRequest"
+    messageKind: "GetAvailableIds"
     count: number
 }
 
@@ -111,7 +111,7 @@ export interface GetAvailableIdsResponse extends QueryMessage {
 
 
 export interface GetAvailableIdsRequest extends QueryMessage {
-    messageKind: "GetAvailableIdsRequest"
+    messageKind: "GetAvailableIds"
     count: number
 }
 
@@ -122,7 +122,7 @@ export interface GetAvailableIdsResponse extends QueryMessage {
 
 
 export interface ListPartitionsRequest extends QueryMessage {
-    messageKind: "ListPartitionsRequest"
+    messageKind: "ListPartitions"
 }
 
 export interface ListPartitionsResponse extends QueryMessage {

--- a/packages/delta-protocol-repository-ws/CHANGELOG.md
+++ b/packages/delta-protocol-repository-ws/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.8.0 — not yet released
+
+* Fix `messageKind` field for request messages of queries to *not* have the "`Request`" suffix.
+
+
+## 0.7.2
+
+(No changes)
+
+
 ## 0.7.1
 
 (The 0.7.0 release was deprecated because its `validation` package was faulty.)

--- a/packages/delta-protocol-repository-ws/src/repository-impl.ts
+++ b/packages/delta-protocol-repository-ws/src/repository-impl.ts
@@ -61,7 +61,7 @@ export class LionWebRepository {
                 return clientMetadata as ClientMetadata
             }
             switch (message.messageKind) {
-                case "SignOnRequest": {
+                case "SignOn": {
                     const { clientId, queryId } = message as SignOnRequest
                     clientMetadata.participationId = `participation-${String.fromCharCode(97 + (nextParticipationIdSequenceNumber++))}`
                     clientMetadata.clientId = clientId
@@ -72,7 +72,7 @@ export class LionWebRepository {
                         protocolMessages: []
                     } as SignOnResponse
                 }
-                case "SignOffRequest": {
+                case "SignOff": {
                     const { queryId } = message as SignOffRequest
                     clientMetadata.participationId = undefined
                     return {

--- a/packages/delta-protocol-test/src/tests/delta-composition.tests.ts
+++ b/packages/delta-protocol-test/src/tests/delta-composition.tests.ts
@@ -54,7 +54,7 @@ describe("combining delta protocol and an “adjacent” delta receiver", () => 
             lowLevelClientInstantiator: ({ receiveMessageOnClient }) =>
                 Promise.resolve({
                     sendMessage: (message) => {
-                        if (message.messageKind === "SignOnRequest") {
+                        if (message.messageKind === "SignOn") {
                             receiveMessageOnClient({
                                 messageKind: "SignOnResponse",
                                 queryId: "q1",

--- a/packages/delta-protocol-test/src/tests/scenarios.tests.ts
+++ b/packages/delta-protocol-test/src/tests/scenarios.tests.ts
@@ -116,7 +116,7 @@ describe(`scenarios (${ansi.colorSchemeExplanationString})`, async function() {
             }]
         }
         const expectedLogItems = [
-            new RepositoryReceivedMessage({}, { messageKind: "SignOnRequest", queryId, repositoryId, deltaProtocolVersion: "2025.1", clientId, protocolMessages: [] } as SignOnRequest),
+            new RepositoryReceivedMessage({}, { messageKind: "SignOn", queryId, repositoryId, deltaProtocolVersion: "2025.1", clientId, protocolMessages: [] } as SignOnRequest),
             new ClientReceivedMessage(clientId, { messageKind: "SignOnResponse", queryId, participationId: "participation-a", protocolMessages: [] } as SignOnResponse),
             new DeltaOccurredOnClient(
                 clientId,

--- a/packages/delta-protocol-test/src/tests/test-utils/mock-low-level-client.tests.ts
+++ b/packages/delta-protocol-test/src/tests/test-utils/mock-low-level-client.tests.ts
@@ -33,7 +33,7 @@ describe("mock low-level client", async function() {
     }
 
     const signOnQueryRequest: SignOnRequest = {
-        messageKind: "SignOnRequest",
+        messageKind: "SignOn",
         deltaProtocolVersion: "2025.1",
         clientId: "A",
         queryId: "query-1",

--- a/packages/json/CHANGELOG.md
+++ b/packages/json/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## 0.7.2
 
-(No changes.)
+(No changes)
 
 
 ## 0.7.1

--- a/packages/validation/CHANGELOG.md
+++ b/packages/validation/CHANGELOG.md
@@ -5,11 +5,12 @@
 * New way to define the structure of the LionWeb JSON format.
 * Add delta format definitions.
 * Propagate `reference` field of `LionWebJsonReferenceTarget` type now being `null`able.
+* Fix `messageKind` field for request messages of queries to *not* have the "`Request`" suffix.
 
 
 ## 0.7.2
 
-(No changes.)
+(No changes)
 
 
 ## 0.7.1

--- a/packages/validation/src/validators/definitions/QueryDefinitions.ts
+++ b/packages/validation/src/validators/definitions/QueryDefinitions.ts
@@ -28,7 +28,7 @@ export const QueryDefinitions: MessageGroup = {
     ],
     messages: [
         {
-            name: "SubscribeToChangingPartitionsRequest",
+            name: "SubscribeToChangingPartitions",
             properties: [
                 {
                     name: "creation",
@@ -54,7 +54,7 @@ export const QueryDefinitions: MessageGroup = {
             ],
         },
         {
-            name: "SubscribeToPartitionContentsRequest",
+            name: "SubscribeToPartitionContents",
             properties: [
                 {
                     name: "partition",
@@ -66,7 +66,7 @@ export const QueryDefinitions: MessageGroup = {
             ],
         },
         {
-            name: "UnsubscribeFromPartitionContentsRequest",
+            name: "UnsubscribeFromPartitionContents",
             properties: [
                 {
                     name: "partition",
@@ -78,7 +78,7 @@ export const QueryDefinitions: MessageGroup = {
             ],
         },
         {
-            name: "SignOnRequest",
+            name: "SignOn",
             properties: [
                 {
                     name: "deltaProtocolVersion",
@@ -104,11 +104,11 @@ export const QueryDefinitions: MessageGroup = {
             ],
         },
         {
-            name: "signOffRequest",
+            name: "signOff",
             properties: [],
         },
         {
-            name: "ReconnectRequest",
+            name: "Reconnect",
             properties: [
                 {
                     name: "participationId",
@@ -127,7 +127,7 @@ export const QueryDefinitions: MessageGroup = {
             ],
         },
         {
-            name: "GetAvailableIdsRequest",
+            name: "GetAvailableIds",
             properties: [
                 {
                     name: "count",
@@ -139,7 +139,7 @@ export const QueryDefinitions: MessageGroup = {
             ],
         },
         {
-            name: "ListPartitionsRequest",
+            name: "ListPartitions",
             properties: [],
         },
     ],


### PR DESCRIPTION
Fixes #274 