### PR TITLE
Fix that references in an interface to Node-s have type Node

### DIFF
--- a/packages/class-core-generator/src/helpers/features.ts
+++ b/packages/class-core-generator/src/helpers/features.ts
@@ -104,8 +104,8 @@ export const tsFieldTypeForFeature = (feature: Feature, imports: Imports): strin
         return `${typeId}${feature.multiple ? "[]" : optionalityPostfix(feature)}`
     }
     if (isReference(feature)) {
-        const typeId = isBuiltinNode(type) ? imports.generic("INodeBase") : imports.entity(type)
-        return `${imports.core("SingleRef")}<${typeId}>${feature.multiple ? "[]" : optionalityPostfix(feature)}`
+        const typeParameter = isBuiltinNode(type) ? imports.core("Node") : imports.entity(type)
+        return `${imports.core("SingleRef")}<${typeParameter}>${feature.multiple ? "[]" : optionalityPostfix(feature)}`
     }
     return `unknown /* [ERROR] can't compute a TS type for feature ${feature.name} on classifier ${feature.classifier.name} whose type has an unhandled/-known meta-type ${type.constructor.name} */`
 }

--- a/packages/class-core-test/src/generator.tests.ts
+++ b/packages/class-core-test/src/generator.tests.ts
@@ -41,6 +41,8 @@ describe(`class-core generator`, () => {
         factory.reference(AConcept, "ref").ofType(node)
         const AnAnnotation = factory.annotation("AnAnnotation").annotating(AConcept)
         factory.reference(AnAnnotation, "ref").ofType(node)
+        const AnInterface = factory.interface("AnInterface")
+        factory.reference(AnInterface, "ref").ofType(node)
         const languageFile = languageFileFor(factory.language, { verbose: false, genericImportLocation: "@lionweb/class-core" })
         isTrue(languageFile.match(/<INodeBase>/) === null, "found <INodeBase>")
         isTrue(languageFile.match(/<Node>/) !== null, "didn’t find <Node>")


### PR DESCRIPTION
Found a problem after upgrading the T. project to the latest beta release.