### PR TITLE
Update with modified delta spec

### DIFF
--- a/documentation/deltas/correspondence.adoc
+++ b/documentation/deltas/correspondence.adoc
@@ -1,9 +1,9 @@
 = Correspondence between commands, events, and deltas
 
 |===
-| command (technical name)                            |spec. §   | event (technical name)                                |spec. §    |delta?
+| command (technical name)                            |spec. §   | event (technical name)                                | spec. §  | delta?
 
-| ChunkedCommand                                      | 5.6.1    | ChunkedEvent                                          | 5.7.1    | &cross;
+| ContinuedCommand                                    | 5.6.1    | ContinuedEvent                                        | 5.7.1    | &cross;
 | AddPartition                                        | 5.6.2.1  | PartitionAdded                                        | 5.7.2.1  | &check;
 | DeletePartition                                     | 5.6.2.2  | PartitionDeleted                                      | 5.7.2.2  | &check;
 | ChangeClassifier                                    | 5.6.3.1  | ClassifierChanged                                     | 5.7.3.1  | &cross;

--- a/packages/delta-protocol-client/src/chunking.ts
+++ b/packages/delta-protocol-client/src/chunking.ts
@@ -18,7 +18,7 @@
 import {
     ContinuedChunkMessage,
     Event,
-    isChunkedEvent,
+    isContinuedEvent,
     maybeChunkPropertyForSplittableEvent,
     Message,
     SplittableMessage
@@ -31,7 +31,7 @@ import { LionWebJsonChunk, LionWebJsonDeltaChunk } from "@lionweb/json"
  * (See § 3.7.1 of the specification of the delta protocol.)
  * Its state is updated through its {@link maybeCompletedMessage} method.
  */
-export class ChunkedInfo {
+export class ChunkingInfo {
 
     /**
      * The received chunks, indexed by their `continuedChunkSequenceNumber`.
@@ -43,7 +43,7 @@ export class ChunkedInfo {
      */
     private numberOfReceivedChunks: number = 0
     /**
-     * The sequence number of the continued chunked marked with `continuedChunkCompleted === true`,
+     * The sequence number of the continued chunk marked with `continuedChunkCompleted === true`,
      * or `-Infinity` initially, so this.numberOfReceivedChunks !== this.lastChunkSequenceNumber + 1,
      * and chunk is not deemed complete already.
      */
@@ -51,7 +51,7 @@ export class ChunkedInfo {
 
     constructor(
         /**
-         * The initial part of the chunked message.
+         * The initial part of the split message.
          * It will be returned from {@link completedMessage} in a modified state.
          */
         private readonly initialMessage: Message,
@@ -106,7 +106,7 @@ export class ChunkedInfo {
  */
 export class EventChunker {
 
-    chunkedInfoBySequenceNumber: { [sequenceNumber: number]: ChunkedInfo } = {}
+    chunkingInfoBySequenceNumber: { [sequenceNumber: number]: ChunkingInfo } = {}
 
     constructor(
         private readonly acceptCompletedEvent: (completedEvent: Event) => void
@@ -114,12 +114,12 @@ export class EventChunker {
     }
 
     handleEvent(event: Event) {
-        if (isChunkedEvent(event)) {
-            if (!(event.chunkedEventSequenceNumber in this.chunkedInfoBySequenceNumber)) {
-                throw new Error(`no (initial) split event with ID ${event.chunkedEventSequenceNumber} known`)
+        if (isContinuedEvent(event)) {
+            if (!(event.continuedEventSequenceNumber in this.chunkingInfoBySequenceNumber)) {
+                throw new Error(`no (initial) split event with ID ${event.continuedEventSequenceNumber} known`)
             }
-            const chunkedInfo = this.chunkedInfoBySequenceNumber[event.chunkedEventSequenceNumber]
-            const maybeCompletedEvent = chunkedInfo.maybeCompletedMessage(event)
+            const chunkingInfo = this.chunkingInfoBySequenceNumber[event.continuedEventSequenceNumber]
+            const maybeCompletedEvent = chunkingInfo.maybeCompletedMessage(event)
             if (maybeCompletedEvent !== undefined) {
                 this.acceptCompletedEvent(maybeCompletedEvent as Event)
             }
@@ -127,10 +127,10 @@ export class EventChunker {
         }
         const chunkProperty = maybeChunkPropertyForSplittableEvent(event)
         if (chunkProperty !== undefined && (event as SplittableMessage).split) {
-            if (event.sequenceNumber in this.chunkedInfoBySequenceNumber) {
+            if (event.sequenceNumber in this.chunkingInfoBySequenceNumber) {
                 throw new Error(`sequence number ${event.sequenceNumber} already associated with an earlier split event`)
             }
-            this.chunkedInfoBySequenceNumber[event.sequenceNumber] = new ChunkedInfo(event, chunkProperty)
+            this.chunkingInfoBySequenceNumber[event.sequenceNumber] = new ChunkingInfo(event, chunkProperty)
             return
         }
         this.acceptCompletedEvent(event)

--- a/packages/delta-protocol-client/src/client.ts
+++ b/packages/delta-protocol-client/src/client.ts
@@ -34,8 +34,8 @@ import {
     GetAvailableIdsRequest,
     GetAvailableIdsResponse,
     InformAboutChangingPartitionsRequest,
-    isChunkedEvent,
-    isChunkedQueryResponse,
+    isContinuedEvent,
+    isContinuedQueryResponse,
     isErrorResponse,
     isEvent,
     isQueryResponse,
@@ -62,7 +62,7 @@ import {
     SubscribeToPartitionContentsResponse,
     UnsubscribeFromPartitionContentsRequest
 } from "@lionweb/delta-protocol-common"
-import { ChunkedInfo } from "./chunking.js"
+import { ChunkingInfo } from "./chunking.js"
 import { LowLevelClient, LowLevelClientInstantiator } from "./low-level-client.js"
 import { priorityQueueAcceptor } from "./priority-queue.js"
 
@@ -117,9 +117,9 @@ export class LionWebClient {
     ) {}
 
     private readonly messageReceiversByQueryId: { [queryId: string]: MessageReceivers } = {}
-    private readonly chunkedInfoByQueryId: { [queryId: string]: ChunkedInfo } = {}
+    private readonly chunkingInfoByQueryId: { [queryId: string]: ChunkingInfo } = {}
 
-    private readonly chunkedInfoByEventSequenceNumber: { [sequenceNumber: number]: ChunkedInfo } = {}
+    private readonly chunkingInfoByEventSequenceNumber: { [sequenceNumber: number]: ChunkingInfo } = {}
 
     static async create({
         repositoryId,
@@ -200,13 +200,13 @@ export class LionWebClient {
                         delete lionWebClient.messageReceiversByQueryId[queryId]
                         return  // ~void
                     }
-                    if (isChunkedQueryResponse(message)) {
-                        const chunkedInfo = lionWebClient.chunkedInfoByQueryId[queryId]
-                        if (chunkedInfo === undefined) {
-                            log(new ClientHadProblem(clientId, `received a chunked query response for a previous message that wasn’t [declared as] split — ignoring the chunked message`))
+                    if (isContinuedQueryResponse(message)) {
+                        const chunkingInfo = lionWebClient.chunkingInfoByQueryId[queryId]
+                        if (chunkingInfo === undefined) {
+                            log(new ClientHadProblem(clientId, `received a continued query response for a previous message that wasn’t [declared as] split — ignoring the continued chunk`))
                             return  // ~void
                         }
-                        const completedMessage = chunkedInfo.maybeCompletedMessage(message)
+                        const completedMessage = chunkingInfo.maybeCompletedMessage(message)
                         if (completedMessage !== undefined) {
                             messageReceivers.resolve(completedMessage)
                             delete lionWebClient.messageReceiversByQueryId[queryId]
@@ -215,7 +215,7 @@ export class LionWebClient {
                     }
                     const chunkProperty = maybeChunkPropertyForSplittableQueryResponse(message)
                     if (chunkProperty !== undefined && (message as SplittableMessage).split) {  // chunkProperty is defined => message must be a SplittableMessage
-                        lionWebClient.chunkedInfoByQueryId[queryId] = new ChunkedInfo(message, chunkProperty)
+                        lionWebClient.chunkingInfoByQueryId[queryId] = new ChunkingInfo(message, chunkProperty)
                     } else {
                         messageReceivers.resolve(message)
                         delete lionWebClient.messageReceiversByQueryId[queryId]
@@ -226,23 +226,23 @@ export class LionWebClient {
                 return  // ~void
             }
             if (isEvent(message)) {
-                if (isChunkedEvent(message)) {
+                if (isContinuedEvent(message)) {
                     const { sequenceNumber } = message
-                    const chunkedInfo = lionWebClient.chunkedInfoByEventSequenceNumber[sequenceNumber]
-                    if (chunkedInfo === undefined) {
-                        log(new ClientHadProblem(clientId, `received a chunked event for a previous message that wasn’t [declared as] split — ignoring the chunked event`))
+                    const chunkingInfo = lionWebClient.chunkingInfoByEventSequenceNumber[sequenceNumber]
+                    if (chunkingInfo === undefined) {
+                        log(new ClientHadProblem(clientId, `received a continued event for a previous message that wasn’t [declared as] split — ignoring the continued event`))
                         return  // ~void
                     }
-                    const completedMessage = chunkedInfo.maybeCompletedMessage(message)
+                    const completedMessage = chunkingInfo.maybeCompletedMessage(message)
                     if (completedMessage !== undefined) {
                         acceptEvent(completedMessage as Event)
-                        delete lionWebClient.chunkedInfoByEventSequenceNumber[sequenceNumber]
+                        delete lionWebClient.chunkingInfoByEventSequenceNumber[sequenceNumber]
                     }
                     return  // ~void
                 }
                 const chunkProperty = maybeChunkPropertyForSplittableEvent(message)
                 if (chunkProperty !== undefined && (message as SplittableMessage).split) {
-                    lionWebClient.chunkedInfoByEventSequenceNumber[message.sequenceNumber] = new ChunkedInfo(message, chunkProperty)
+                    lionWebClient.chunkingInfoByEventSequenceNumber[message.sequenceNumber] = new ChunkingInfo(message, chunkProperty)
                 } else {
                     acceptEvent(message)
                 }

--- a/packages/delta-protocol-client/src/index.ts
+++ b/packages/delta-protocol-client/src/index.ts
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2025 TRUMPF Laser SE and other contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export { ChunkedInfo, EventChunker } from "./chunking.js"
+export { ChunkingInfo, EventChunker } from "./chunking.js"
 
 export { LionWebClient } from "./client.js"
 export type { LionWebClientParameters } from "./client.js"

--- a/packages/delta-protocol-common/src/payload/command-types.ts
+++ b/packages/delta-protocol-common/src/payload/command-types.ts
@@ -36,8 +36,8 @@ export interface CustomCommand extends Command {
 // in order of the specification (§ 5.7):
 
 /** § 5.7.1 */
-export interface ChunkedCommand extends Command, ContinuedChunkMessage {
-    messageKind: "ChunkedCommand"
+export interface ContinuedCommand extends Command, ContinuedChunkMessage {
+    messageKind: "ContinuedCommand"
 }
 
 /** § 5.7.2.1 */

--- a/packages/delta-protocol-common/src/payload/common.ts
+++ b/packages/delta-protocol-common/src/payload/common.ts
@@ -15,7 +15,7 @@
 // SPDX-FileCopyrightText: 2025 TRUMPF Laser SE and other contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { LionWebId, LionWebJsonChunk } from "@lionweb/json"
+import { LionWebId, LionWebJsonDeltaChunk } from "@lionweb/json"
 import { isValidIdentifier } from "@lionweb/core"
 
 export interface Message {
@@ -50,7 +50,7 @@ export interface DeltaAdditionalInfo extends Message {
  * (See § 3.7.1 of the specification of the delta protocol.)
  */
 export interface ContinuedChunkMessage extends Message {
-    chunk: LionWebJsonChunk
+    chunk: LionWebJsonDeltaChunk
     continuedChunkCompleted: boolean
     continuedChunkSequenceNumber: number
 }

--- a/packages/delta-protocol-common/src/payload/event-types.ts
+++ b/packages/delta-protocol-common/src/payload/event-types.ts
@@ -30,7 +30,7 @@ export interface Event extends DeltaAdditionalInfo {
 
 /**
  * Super-interface for events which have the `originCommands` parameter,
- * which is every event *except* {@link ChunkedEvent}.
+ * which is every event *except* {@link ContinuedEvent}.
  */
 export interface OriginatedEvent extends Event {
     originCommands: CommandSource[]
@@ -52,11 +52,11 @@ export interface CustomEvent extends Event {
 /**
  * § 5.8.1
  *
- * (ChunkedEvent is the only event *not* to have an `originCommands` parameter.)
+ * (ContinuedEvent is the only event *not* to have an `originCommands` parameter.)
  */
-export interface ChunkedEvent extends Event, ContinuedChunkMessage {
-    messageKind: "ChunkedEvent"
-    chunkedEventSequenceNumber: number  // === sequence number of split event (i.e., the initial message)
+export interface ContinuedEvent extends Event, ContinuedChunkMessage {
+    messageKind: "ContinuedEvent"
+    continuedEventSequenceNumber: number  // === sequence number of split event (i.e., the initial message)
 }
 
 /** § 5.8.2.1 */
@@ -336,7 +336,7 @@ export interface ErrorEvent extends OriginatedEvent {
 
 const eventMessageKinds = mapFrom(
     [
-        "ChunkedEvent",
+        "ContinuedEvent",
         "PartitionAdded",
         "PartitionDeleted",
         "ClassifierChanged",
@@ -373,8 +373,8 @@ const eventMessageKinds = mapFrom(
 export const isEvent = (message: Message): message is Event =>
     message.messageKind in eventMessageKinds
 
-export const isChunkedEvent = (message: Message): message is ChunkedEvent =>
-    message.messageKind === "ChunkedEvent"
+export const isContinuedEvent = (message: Message): message is ContinuedEvent =>
+    message.messageKind === "ContinuedEvent"
 
 /**
  * (See § 3.7.1 of the specification of the delta protocol.)
@@ -396,5 +396,5 @@ export const maybeChunkPropertyForSplittableEvent = (event: Event): (string | un
  * @return the `originCommands` field from an {@link Event} if it has one, and `[]` otherwise.
  */
 export const originCommandsFrom = (event: Event): CommandSource[] =>
-    isChunkedEvent(event) ? [] : (event as OriginatedEvent).originCommands
+    isContinuedEvent(event) ? [] : (event as OriginatedEvent).originCommands
 

--- a/packages/delta-protocol-common/src/payload/query-types.ts
+++ b/packages/delta-protocol-common/src/payload/query-types.ts
@@ -63,8 +63,8 @@ export interface ErrorResponse extends QueryMessage {
 
 
 /** § 5.5.1.2 (response) */
-export interface ChunkedQueryResponse extends QueryMessage, ContinuedChunkMessage {
-    messageKind: "ChunkedQueryResponse"
+export interface ContinuedQueryResponse extends QueryMessage, ContinuedChunkMessage {
+    messageKind: "ContinuedQueryResponse"
 }
 
 
@@ -213,7 +213,7 @@ export interface ListAndSubscribePartitionsResponse extends QueryMessage, Splitt
 
 const queryMessageKinds = [
     "Error",
-    "ChunkedQuery",
+    "ContinuedQuery",
     "SubscribeToChangingPartitions",
     "InformAboutChangingPartitions",
     "SubscribeToPartitionContents",
@@ -234,8 +234,8 @@ export const isQueryResponse = (message: Message): message is QueryMessage =>
 export const isErrorResponse = (message: Message): message is ErrorResponse =>
     message.messageKind === "ErrorResponse"
 
-export const isChunkedQueryResponse = (message: Message): message is ChunkedQueryResponse =>
-    message.messageKind === "ChunkedQueryResponse"
+export const isContinuedQueryResponse = (message: Message): message is ContinuedQueryResponse =>
+    message.messageKind === "ContinuedQueryResponse"
 
 /**
  * (See § 3.7.1 of the specification of the delta protocol.)

--- a/packages/delta-protocol-test/src/tests/chunking.tests.ts
+++ b/packages/delta-protocol-test/src/tests/chunking.tests.ts
@@ -19,11 +19,11 @@ import { expect } from "chai"
 
 import { TestLanguageBase } from "@lionweb/class-core-test-language"
 import { Classifier, Containment, metaPointerForFeature } from "@lionweb/core"
-import { ChunkedInfo, EventChunker } from "@lionweb/delta-protocol-client"
+import { ChunkingInfo, EventChunker } from "@lionweb/delta-protocol-client"
 import {
     ChildAddedEvent,
-    ChunkedEvent,
     ContinuedChunkMessage,
+    ContinuedEvent,
     Event,
     PartitionAddedEvent,
     SplittableMessage
@@ -82,45 +82,45 @@ describe("chunking (in isolation)", () => {
 
     it("immediately finished, no merging", () => {
         const initialMessage: TestMessage = testMessageWith()
-        const chunkedInfo = new ChunkedInfo(initialMessage, "chunk")
-        expect(chunkedInfo.maybeCompletedMessage(testChunkMessage(0, true))).to.deep.equal(testMessageWith())
+        const chunkingInfo = new ChunkingInfo(initialMessage, "chunk")
+        expect(chunkingInfo.maybeCompletedMessage(testChunkMessage(0, true))).to.deep.equal(testMessageWith())
     })
 
     it("immediately finished, some merging", () => {
         const node1 = testNode("node1")
         const node2 = testNode("node2")
         const initialMessage: TestMessage = testMessageWith(node1)
-        const chunkedInfo = new ChunkedInfo(initialMessage, "chunk")
-        expect(chunkedInfo.maybeCompletedMessage(testChunkMessage(0, true, node2))).to.deep.equal(testMessageWith(node1, node2))
+        const chunkingInfo = new ChunkingInfo(initialMessage, "chunk")
+        expect(chunkingInfo.maybeCompletedMessage(testChunkMessage(0, true, node2))).to.deep.equal(testMessageWith(node1, node2))
     })
 
     it("multiple chunks, out of order, no merging", () => {
         const initialMessage: TestMessage = testMessageWith()
-        const chunkedInfo = new ChunkedInfo(initialMessage, "chunk")
-        expect(chunkedInfo.maybeCompletedMessage(testChunkMessage(2, true))).to.equal(undefined)
-        expect(chunkedInfo.maybeCompletedMessage(testChunkMessage(0, false))).to.equal(undefined)
-        expect(chunkedInfo.maybeCompletedMessage(testChunkMessage(1, false))).to.deep.equal(testMessageWith())
+        const chunkingInfo = new ChunkingInfo(initialMessage, "chunk")
+        expect(chunkingInfo.maybeCompletedMessage(testChunkMessage(2, true))).to.equal(undefined)
+        expect(chunkingInfo.maybeCompletedMessage(testChunkMessage(0, false))).to.equal(undefined)
+        expect(chunkingInfo.maybeCompletedMessage(testChunkMessage(1, false))).to.deep.equal(testMessageWith())
     })
 
     it("fault scenarios", () => {
         const initialMessage: TestMessage = testMessageWith()
-        const chunkedInfo = new ChunkedInfo(initialMessage, "chunk")
-        expect(chunkedInfo.maybeCompletedMessage(testChunkMessage(0, false))).to.equal(undefined)
+        const chunkingInfo = new ChunkingInfo(initialMessage, "chunk")
+        expect(chunkingInfo.maybeCompletedMessage(testChunkMessage(0, false))).to.equal(undefined)
         expect(
             () => {
-                chunkedInfo.maybeCompletedMessage(testChunkMessage(0, false))
+                chunkingInfo.maybeCompletedMessage(testChunkMessage(0, false))
             }
         ).to.throw("received continued chunk with sequence number 0 more than once")
-        expect(chunkedInfo.maybeCompletedMessage(testChunkMessage(2, true))).to.equal(undefined)
+        expect(chunkingInfo.maybeCompletedMessage(testChunkMessage(2, true))).to.equal(undefined)
         expect(
             () => {
-                chunkedInfo.maybeCompletedMessage(testChunkMessage(1, true))
+                chunkingInfo.maybeCompletedMessage(testChunkMessage(1, true))
             }
         ).to.throw("continued chunk sequence declared complete more than once")
-        expect(chunkedInfo.maybeCompletedMessage(testChunkMessage(1, false))).to.deep.equal(testMessageWith())
+        expect(chunkingInfo.maybeCompletedMessage(testChunkMessage(1, false))).to.deep.equal(testMessageWith())
         expect(
             () => {
-                chunkedInfo.maybeCompletedMessage(testChunkMessage(1, false))
+                chunkingInfo.maybeCompletedMessage(testChunkMessage(1, false))
             }
         ).to.throw("split message already completed")
     })
@@ -148,19 +148,19 @@ const childAddedEvent = (sequenceNumber: number, parent: LionWebId, newChild: Li
     originCommands: []
 })
 
-const testChunkedEvent = (sequenceNumber: number, continuedChunkSequenceNumber: number, continuedChunkCompleted: boolean, chunkedEventSequenceNumber: number, ...nodes: LionWebJsonNode[]): ChunkedEvent => ({
-    messageKind: "ChunkedEvent",
+const testContinuedEvent = (sequenceNumber: number, continuedChunkSequenceNumber: number, continuedChunkCompleted: boolean, continuedEventSequenceNumber: number, ...nodes: LionWebJsonNode[]): ContinuedEvent => ({
+    messageKind: "ContinuedEvent",
     chunk: testChunk(...nodes),
     continuedChunkCompleted,
     continuedChunkSequenceNumber,
-    chunkedEventSequenceNumber,
+    continuedEventSequenceNumber,
     sequenceNumber,
     additionalInfos: []
 })
 
 
 
-describe("handling chunked events", () => {
+describe("handling continued events", () => {
 
     const partition = testNode("partition", testLanguage.TestPartition)
     const node1 = testNode("node1")
@@ -174,9 +174,9 @@ describe("handling chunked events", () => {
 
     it("this is how it’s done for 1 initial event", () => {
         const initialEvent = partitionAddedEvent(0, true, partition, node1)
-        const chunkedInfo = new ChunkedInfo(initialEvent, "newPartition")
-        expect(chunkedInfo.maybeCompletedMessage(testChunkedEvent(1, 1, true, initialEvent.sequenceNumber, node2))).to.equal(undefined)
-        const combinedEvent = chunkedInfo.maybeCompletedMessage(testChunkedEvent(2, 0, false, initialEvent.sequenceNumber, node3)) as PartitionAddedEvent
+        const chunkingInfo = new ChunkingInfo(initialEvent, "newPartition")
+        expect(chunkingInfo.maybeCompletedMessage(testContinuedEvent(1, 1, true, initialEvent.sequenceNumber, node2))).to.equal(undefined)
+        const combinedEvent = chunkingInfo.maybeCompletedMessage(testContinuedEvent(2, 0, false, initialEvent.sequenceNumber, node3)) as PartitionAddedEvent
         expect(combinedEvent).to.deep.equal(partitionAddedEvent(0, true, partition, node1, node3, node2))
     })
 
@@ -190,14 +190,14 @@ describe("handling chunked events", () => {
         eventChunker.handleEvent(initialEvent)
         expect(completedEvents.length).to.equal(0)
 
-        eventChunker.handleEvent(testChunkedEvent(1, 1, true, initialEvent.sequenceNumber, node2))
+        eventChunker.handleEvent(testContinuedEvent(1, 1, true, initialEvent.sequenceNumber, node2))
         expect(completedEvents.length).to.equal(0)
 
         const event2 = childAddedEvent(2, "partition", testChunk(node4), testLanguage.TestPartition_links, 0)
         eventChunker.handleEvent(event2)
         expect(completedEvents).to.deep.equal([event2])
 
-        eventChunker.handleEvent(testChunkedEvent(3, 0, false, initialEvent.sequenceNumber, node3))
+        eventChunker.handleEvent(testContinuedEvent(3, 0, false, initialEvent.sequenceNumber, node3))
         const combinedEvent = completedEvents[1]
         expect(combinedEvent).to.deep.equal(partitionAddedEvent(0, true, partition, node1, node3, node2))
     })
@@ -207,7 +207,7 @@ describe("handling chunked events", () => {
 
         expect(
             () => {
-                eventChunker.handleEvent(testChunkedEvent(1, 0, false, 0))
+                eventChunker.handleEvent(testContinuedEvent(1, 0, false, 0))
             }
         ).to.throw("no (initial) split event with ID 0 known")
 


### PR DESCRIPTION
- rename “chunked command|event|query-response" -> "continued _"
- rename “chunked info” -> “chunking info”
- fix type of chunk field of continued chunk message