### PR TITLE
Add the 2 methods added to NodeBase also to INodeBase

### DIFF
--- a/packages/class-core-test/src/base-types.tests.ts
+++ b/packages/class-core-test/src/base-types.tests.ts
@@ -15,10 +15,12 @@
 // SPDX-FileCopyrightText: 2025 TRUMPF Laser SE and other contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { INodeBase, NodeBase } from "@lionweb/class-core"
 import { LinkTestConcept } from "@lionweb/class-core-test-language"
 import { sameMembers } from "./assertions.js"
 
 describe("internals of base types", () => {
+
     it("children", () => {
         const parent = LinkTestConcept.create("parent")
         const child1 = LinkTestConcept.create("child1")
@@ -46,5 +48,13 @@ describe("internals of base types", () => {
         parent.addReference_1_n(child4)
         sameMembers(parent.referenceTargets, [child1, child2, child3, child4])
     })
+
+    it("NodeBase and INodeBase are assignment-compatible", () => {
+        const nodeBase = LinkTestConcept.create("ltc")
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const nodeBase2: NodeBase = (nodeBase as INodeBase)
+        // ^^^ compiles, so an INodeBase can be assigned as a NodeBase
+    })
+
 })
 

--- a/packages/class-core/CHANGELOG.md
+++ b/packages/class-core/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 0.10.0 — not yet released
 
-* Add `move[AndReplace]OffsetBased[Directly]` functions to value managers for (multi-valued) containments and annotations.
-* Update `ChildMoved[AndReplaced]InSameContainmentDelta` and `AnnotationMoved[AndReplaced]Delta` classes, as well as associated appliers and inverters, to align with latest, offset-based versions of those deltas.
+* Add support for offset-based move and move+replace actions:
+  * Add `move[AndReplace]OffsetBased[Directly]` functions to value managers for (multi-valued) containments and annotations.
+  * Add `move[AndReplace]AnnotationOffsetBased` methods to both `NodeBase` and `INodeBase` (so instances are assignment-compatible).
+  * Update `ChildMoved[AndReplaced]InSameContainmentDelta` and `AnnotationMoved[AndReplaced]Delta` classes, as well as associated appliers and inverters, to align with latest, offset-based versions of those deltas.
 
 
 ## 0.9.2

--- a/packages/class-core/src/base-types.ts
+++ b/packages/class-core/src/base-types.ts
@@ -152,6 +152,21 @@ export interface INodeBase extends Node {
      */
     removeAnnotation(annotation: INodeBase): void;
 
+    /**
+     * Moves the annotation that’s initially at index `oldIndex` by `indexOffset` positions
+     * to index `oldIndex + indexOffset`, shifting the other annotations as necessary.
+     */
+    moveAnnotationOffsetBased(oldIndex: number, indexOffset: number): void;
+
+    /**
+     * Moves the annotation that’s initially at index `oldIndex` by `indexOffset` positions
+     * to index `oldIndex + indexOffset`,
+     * replacing the annotation that was at that index initially.
+     * This deletes the replaced annotation, including all its descendants,
+     * but does NOT change references to any of the deleted nodes.
+     */
+    moveAndReplaceAnnotationOffsetBased(oldIndex: number, indexOffset: number): void;
+
 
     /**
      * @return the {@link Feature features} of the {@link Classifier} that is this node's meta-type,


### PR DESCRIPTION
This is needed to make an instance of NodeBase assignable to an INodeBase under strict(er) TypeScript compilation.