### PR TITLE
Show annotates in PlantUML diagram also for feature-rich annotations

### DIFF
--- a/packages/io-lionweb-mps-specific/meta/io.lionweb.mps.specific.puml
+++ b/packages/io-lionweb-mps-specific/meta/io.lionweb.mps.specific.puml
@@ -9,19 +9,23 @@ annotation ConceptDescription {
   conceptShortDescription: String?
   helpUrl: String?
 }
+ConceptDescription ..# Classifier : <i>annotates</i>
 
 annotation Deprecated {
   comment: String?
   build: String?
 }
+Deprecated ..# IKeyed : <i>annotates</i>
 
 annotation KeyedDescription {
   documentation: String?
 }
+KeyedDescription ..# IKeyed : <i>annotates</i>
 
 annotation ShortDescription {
   description: String?
 }
+ShortDescription ..# Node : <i>annotates</i>
 
 annotation VirtualPackage implements INamed
 VirtualPackage ..# Node : <i>annotates</i>

--- a/packages/utilities/src/m3/diagrams/PlantUML-generator.ts
+++ b/packages/utilities/src/m3/diagrams/PlantUML-generator.ts
@@ -66,9 +66,10 @@ const generateForAnnotation = ({ name, features, extends: extends_, implements: 
         fragments.push(`implements`, implements_.filter(isRef).map(nameOf).sort().join(", "))
     }
     const nonRelationalFeatures_ = nonRelationalFeatures(features)
+    const annotatesLine = isResolvedReference(annotates) ? `${name} ..# ${annotates.name} : <i>annotates</i>` : []
     return nonRelationalFeatures_.length === 0
-        ? [`${fragments.join(" ")}`, isResolvedReference(annotates) ? `${name} ..# ${annotates.name} : <i>annotates</i>` : [], ``]
-        : [`${fragments.join(" ")} {`, indented(nonRelationalFeatures_.map(generateForNonRelationalFeature)), `}`, ``]
+        ? [`${fragments.join(" ")}`, annotatesLine, ``]
+        : [`${fragments.join(" ")} {`, indented(nonRelationalFeatures_.map(generateForNonRelationalFeature)), `}`, annotatesLine, ``]
 }
 
 const generateForConcept = ({ name, features, abstract: abstract_, extends: extends_, implements: implements_, partition }: Concept) => {


### PR DESCRIPTION
This fixes issue #356.
That the fix works is shown by the additional lines in the `io.lionweb.mps.specific.puml` PlantUML file.