### PR TITLE
Fix bug in insertAtIndex method of multi-valued containment managers

### DIFF
--- a/packages/class-core-test/src/value-managers/containment_0_1.tests.ts
+++ b/packages/class-core-test/src/value-managers/containment_0_1.tests.ts
@@ -152,7 +152,7 @@ describe("write access to a [0..1] containment through .set", () => {
         deepEqual(deltas[2], new ChildMovedFromOtherContainmentInSameParentDelta(parent, testLanguageBase.LinkTestConcept_containment_1, 0, child, testLanguageBase.LinkTestConcept_containment_0_1, 0));
     });
 
-    it("moving a child within same containment (no ChildMovedInSameContainmentDelta)", () => {
+    it("assigning a child idempotently", () => {
         const [receiveDelta, deltas] = collectingDeltaReceiver();
         const parent = attachedLinkTestConcept("parent", receiveDelta);
         const child = LinkTestConcept.create("child", receiveDelta);

--- a/packages/class-core-test/src/value-managers/containment_0_n.tests.ts
+++ b/packages/class-core-test/src/value-managers/containment_0_n.tests.ts
@@ -237,7 +237,7 @@ describe("[0..n] containment", () => {
         equal(child1.containment, testLanguageBase.LinkTestConcept_containment_0_n);
         equal(child2.parent, parent1);
         equal(child2.containment, testLanguageBase.LinkTestConcept_containment_0_n);
-        assertDeltaEmitted(new ChildMovedInSameContainmentDelta(parent1, testLanguageBase.LinkTestConcept_containment_0_n, 1, 0,child1));
+        assertDeltaEmitted(new ChildMovedInSameContainmentDelta(parent1, testLanguageBase.LinkTestConcept_containment_0_n, 1, -1, child1));
 
         // action+check:
         parent1.addContainment_1_nAtIndex(child2, 0);   // child2 moved from parent1.containment_0_n[1] to parent1.containment_1_n[0]

--- a/packages/class-core-test/src/value-managers/containment_1.tests.ts
+++ b/packages/class-core-test/src/value-managers/containment_1.tests.ts
@@ -176,7 +176,7 @@ describe("write access to a [1] containment through .set", () => {
         deepEqual(deltas[2], new ChildMovedFromOtherContainmentInSameParentDelta(parent, testLanguageBase.LinkTestConcept_containment_0_1, 0, child, testLanguageBase.LinkTestConcept_containment_1, 0));
     });
 
-    it("moving a child within same containment (no ChildMovedInSameContainmentDelta)", () => {
+    it("assigning a child idempotently", () => {
         const [receiveDelta, deltas] = collectingDeltaReceiver();
         const parent = attachedLinkTestConcept("parent", receiveDelta);
         const child = LinkTestConcept.create("child", receiveDelta);

--- a/packages/class-core/CHANGELOG.md
+++ b/packages/class-core/CHANGELOG.md
@@ -21,6 +21,9 @@
   * Also add a `nodes` field to `DetailedDeserialization`, containing *all* deserialized nodes.
 * Change all occurrences of `LionWebJsonChunk` type in delta serialization types to `LionWebJsonDeltaChunk`.
 * Expose a `serializeAsDeltaChunk` function — and propagate its use to the delta protocol packages.
+  * Fix a bug in the value managers for multi-valued containments:
+    a call to `insertAtIndex` with a child that’s already in the managed multi-valued containment now results in a `ChildMovedInSameContainment` delta with a correct `indexOffset`
+    (instead of the effective `newIndex`).
 
 
 ## 0.9.2

--- a/packages/class-core/src/value-managers/containments.ts
+++ b/packages/class-core/src/value-managers/containments.ts
@@ -275,7 +275,7 @@ export abstract class MultiContainmentValueManager<T extends INodeBase> extends 
                 if (newChild.containment === this.containment) {
                     const oldIndex = this.children.indexOf(newChild);
                     this.moveDirectly(oldIndex, newIndex);
-                    this.emitDelta(() => new ChildMovedInSameContainmentDelta(this.container, this.containment, oldIndex, newIndex, newChild));
+                    this.emitDelta(() => new ChildMovedInSameContainmentDelta(this.container, this.containment, oldIndex, newIndex - oldIndex, newChild));
                 } else {
                     const oldIndex = removeFromContainment(newChild);
                     checkIndex(newIndex, this.children.length, true);


### PR DESCRIPTION
Quasi-courtesy PR: will merge this evening at the latest.